### PR TITLE
Harden frontend resilience and backend API contracts

### DIFF
--- a/src/api/services/__tests__/adminService.test.js
+++ b/src/api/services/__tests__/adminService.test.js
@@ -1,0 +1,40 @@
+import apiClient from "api/apiClient";
+import { sessionManager } from "platform/auth/sessionManager";
+import adminService from "../adminService";
+
+jest.mock("api/apiClient", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+}));
+
+jest.mock("platform/auth/sessionManager", () => ({
+  sessionManager: {
+    hydrate: jest.fn(),
+  },
+}));
+
+describe("adminService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loads the current admin through the backend user admin route", async () => {
+    sessionManager.hydrate.mockReturnValue({ user: { id: "u1" } });
+    apiClient.get.mockResolvedValue({
+      data: { id: "a1", user_id: "u1", admin_level: "super_admin" },
+    });
+
+    const result = await adminService.getCurrentSystemAdminProfile();
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/v1/admin/system-admins/user/u1"
+    );
+    expect(result).toEqual({
+      id: "a1",
+      user_id: "u1",
+      admin_level: "super_admin",
+    });
+  });
+});

--- a/src/api/services/__tests__/patientService.test.js
+++ b/src/api/services/__tests__/patientService.test.js
@@ -1,0 +1,51 @@
+import apiClient from "api/apiClient";
+import { sessionManager } from "platform/auth/sessionManager";
+import patientService from "../patientService";
+
+jest.mock("api/apiClient", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+}));
+
+jest.mock("platform/auth/sessionManager", () => ({
+  sessionManager: {
+    hydrate: jest.fn(),
+  },
+}));
+
+describe("patientService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("loads the current patient through the backend user profile route", async () => {
+    sessionManager.hydrate.mockReturnValue({ user: { id: "u1" } });
+    apiClient.get.mockResolvedValue({ data: { id: "p1", user_id: "u1" } });
+
+    const result = await patientService.getCurrentPatientProfile();
+
+    expect(apiClient.get).toHaveBeenCalledWith("/api/v1/patients/user/u1");
+    expect(result).toEqual({ id: "p1", user_id: "u1" });
+  });
+
+  it("upserts patient profiles through the backend create endpoint", async () => {
+    apiClient.post.mockResolvedValue({ data: { id: "p1" } });
+
+    await patientService.upsertPatientProfile({
+      user_id: "u1",
+      first_name: "Amina",
+      last_name: "Dube",
+      country: "South Africa",
+    });
+
+    expect(apiClient.post).toHaveBeenCalledWith("/api/v1/patients", {
+      user_id: "u1",
+      first_name: "Amina",
+      last_name: "Dube",
+      country: "South Africa",
+    });
+    expect(apiClient.put).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/services/__tests__/providerService.test.js
+++ b/src/api/services/__tests__/providerService.test.js
@@ -1,0 +1,43 @@
+import apiClient from "api/apiClient";
+import providerService from "../providerService";
+
+jest.mock("api/apiClient", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+}));
+
+describe("providerService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates approved verification status through the backend verify route", async () => {
+    apiClient.put.mockResolvedValue({ data: { message: "Clinic verified successfully" } });
+
+    const result = await providerService.updateVerifyClinic("c1", {
+      status: "verified",
+      verified_by: "u1",
+      notes: "Approved",
+    });
+
+    expect(apiClient.put).toHaveBeenCalledWith(
+      "/api/v1/providers/clinics/c1/verify",
+      { verified_by: "u1", notes: "Approved" }
+    );
+    expect(result).toEqual({ message: "Clinic verified successfully" });
+  });
+
+  it("does not call the removed verification-status endpoint for rejected clinics", async () => {
+    await expect(
+      providerService.updateVerifyClinic("c1", {
+        status: "rejected",
+        verified_by: "u1",
+        notes: "Missing license",
+      })
+    ).rejects.toThrow("Clinic rejection is not supported by the backend API");
+
+    expect(apiClient.put).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/services/adminService.js
+++ b/src/api/services/adminService.js
@@ -1,4 +1,17 @@
 import apiClient from "api/apiClient";
+import { sessionManager } from "platform/auth/sessionManager";
+
+const getCurrentUserId = () => {
+  const userId = sessionManager.hydrate()?.user?.id;
+  if (!userId) {
+    throw new Error("Current user is not available");
+  }
+  return userId;
+};
+
+const unsupportedAdminOperation = (operation) => {
+  throw new Error(`${operation} is not supported by the backend admin API`);
+};
 
 /**
  * Admin Service
@@ -45,10 +58,9 @@ const adminService = {
    * @returns {Promise<Object>} System admin profile
    */
   getSystemAdmin: async (adminId) => {
-    const response = await apiClient.get(
-      `/api/v1/admin/system-admins/${adminId}`
+    return unsupportedAdminOperation(
+      `Loading system admin by profile ID ${adminId}`
     );
-    return response.data;
   },
 
   /**
@@ -58,11 +70,9 @@ const adminService = {
    * @returns {Promise<Object>} Updated system admin profile
    */
   updateSystemAdmin: async (adminId, data) => {
-    const response = await apiClient.put(
-      `/api/v1/admin/system-admins/${adminId}`,
-      data
+    return unsupportedAdminOperation(
+      `Updating system admin by profile ID ${adminId}`
     );
-    return response.data;
   },
 
   /**
@@ -71,10 +81,9 @@ const adminService = {
    * @returns {Promise<Object>} Success message
    */
   deleteSystemAdmin: async (adminId) => {
-    const response = await apiClient.delete(
-      `/api/v1/admin/system-admins/${adminId}`
+    return unsupportedAdminOperation(
+      `Deleting system admin by profile ID ${adminId}`
     );
-    return response.data;
   },
 
   /**
@@ -83,10 +92,9 @@ const adminService = {
    * @returns {Promise<Object>} Success message
    */
   deleteSystemAdminByUserId: async (userId) => {
-    const response = await apiClient.delete(
-      `/api/v1/admin/system-admins/user/${userId}`
+    return unsupportedAdminOperation(
+      `Deleting system admin by user ID ${userId}`
     );
-    return response.data;
   },
 
   /**
@@ -100,20 +108,8 @@ const adminService = {
    * @param {number} params.offset - Results offset
    * @returns {Promise<Object>} Search results
    */
-  searchSystemAdmins: async (params) => {
-    const queryParams = new URLSearchParams();
-
-    // Add all defined parameters
-    Object.keys(params).forEach((key) => {
-      if (params[key] !== undefined && params[key] !== null) {
-        queryParams.append(key, params[key]);
-      }
-    });
-
-    const response = await apiClient.get(
-      `/api/v1/admin/system-admins/search?${queryParams.toString()}`
-    );
-    return response.data;
+  searchSystemAdmins: async () => {
+    return unsupportedAdminOperation("Searching system admins");
   },
 
   /**
@@ -121,8 +117,7 @@ const adminService = {
    * @returns {Promise<Object>} System admin profile
    */
   getCurrentSystemAdminProfile: async () => {
-    const response = await apiClient.get("/api/v1/admin/system-admins/me");
-    return response.data;
+    return adminService.getSystemAdminByUserId(getCurrentUserId());
   },
 
   /**
@@ -131,8 +126,7 @@ const adminService = {
    * @returns {Promise<Object>} Created/updated system admin profile
    */
   upsertSystemAdminProfile: async (data) => {
-    const response = await apiClient.put("/api/v1/admin/system-admins/me", data);
-    return response.data;
+    return adminService.createSystemAdmin(data);
   },
 
   /**
@@ -140,10 +134,49 @@ const adminService = {
    * @returns {Promise<Object>} Admin permissions
    */
   getAdminPermissions: async () => {
-    const response = await apiClient.get(
-      "/api/v1/admin/system-admins/me/permissions"
-    );
-    return response.data;
+    const admin = await adminService.getCurrentSystemAdminProfile();
+    return adminService.normalizePermissionPayload(admin);
+  },
+
+  normalizePermissionPayload: (payload) => {
+    const source = payload ?? {};
+    const directPermissions =
+      source.permissions && typeof source.permissions === "object"
+        ? source.permissions
+        : {};
+
+    const getBool = (obj, snakeKey, camelKey) => {
+      const raw =
+        obj?.[snakeKey] ?? obj?.[camelKey] ?? directPermissions?.[snakeKey];
+      if (typeof raw === "boolean") return raw;
+      return raw === 1 || raw === "1" || raw === "true";
+    };
+
+    return {
+      adminLevel:
+        source.adminLevel ??
+        source.admin_level ??
+        null,
+      assignedRegions:
+        source.assignedRegions ??
+        source.assigned_regions ??
+        [],
+      canManageUsers:
+        getBool(source, "can_manage_users", "canManageUsers") ||
+        getBool(directPermissions, "can_manage_users", "canManageUsers"),
+      canManageClinics:
+        getBool(source, "can_manage_clinics", "canManageClinics") ||
+        getBool(directPermissions, "can_manage_clinics", "canManageClinics"),
+      canManageContent:
+        getBool(source, "can_manage_content", "canManageContent") ||
+        getBool(directPermissions, "can_manage_content", "canManageContent"),
+      canViewAnalytics:
+        getBool(source, "can_view_analytics", "canViewAnalytics") ||
+        getBool(directPermissions, "can_view_analytics", "canViewAnalytics"),
+      canManageSystem:
+        getBool(source, "can_manage_system", "canManageSystem") ||
+        getBool(directPermissions, "can_manage_system", "canManageSystem"),
+    };
   },
 
   /**
@@ -153,14 +186,15 @@ const adminService = {
    */
   hasPermission: async (permission) => {
     const permissions = await adminService.getAdminPermissions();
+    const permissionsMap = adminService.normalizePermissionPayload(permissions);
 
     // Map permission strings to properties
     const permissionMap = {
-      manage_users: permissions.canManageUsers,
-      manage_clinics: permissions.canManageClinics,
-      manage_content: permissions.canManageContent,
-      view_analytics: permissions.canViewAnalytics,
-      manage_system: permissions.canManageSystem,
+      manage_users: permissionsMap.canManageUsers,
+      manage_clinics: permissionsMap.canManageClinics,
+      manage_content: permissionsMap.canManageContent,
+      view_analytics: permissionsMap.canViewAnalytics,
+      manage_system: permissionsMap.canManageSystem,
     };
 
     return permissionMap[permission] || false;

--- a/src/api/services/appointmentService.js
+++ b/src/api/services/appointmentService.js
@@ -3,25 +3,20 @@ import apiClient from "../apiClient";
 const appointmentService = {
   // Create appointment (already exists)
   bookAppointment: async (data) => {
-    const response = await apiClient.post(
-      "/api/v1/appointments/appointments",
-      data
-    );
+    const response = await apiClient.post("/api/v1/appointments", data);
     return response.data;
   },
 
   // Get appointment by ID
   getAppointmentById: async (id) => {
-    const response = await apiClient.get(
-      `/api/v1/appointments/appointments/${id}`
-    );
+    const response = await apiClient.get(`/api/v1/appointments/${id}`);
     return response.data;
   },
 
   // Get appointments by patient
   getAppointmentsByPatient: async (patientId) => {
     const response = await apiClient.get(
-      `/api/v1/appointments/appointments/patient/${patientId}`
+      `/api/v1/appointments/patient/${patientId}`
     );
     return response.data;
   },
@@ -29,7 +24,7 @@ const appointmentService = {
   // Get appointments by clinic
   getAppointmentsByClinic: async (clinicId) => {
     const response = await apiClient.get(
-      `/api/v1/appointments/appointments/clinic/${clinicId}`
+      `/api/v1/appointments/clinic/${clinicId}`
     );
     return response.data;
   },
@@ -37,7 +32,7 @@ const appointmentService = {
   // Get appointments by clinic and date
   getAppointmentsByClinicAndDate: async (clinicId, date) => {
     const response = await apiClient.get(
-      `/api/v1/appointments/appointments/clinic/${clinicId}/date/${date}`
+      `/api/v1/appointments/clinic/${clinicId}/date/${date}`
     );
     return response.data;
   },
@@ -45,7 +40,7 @@ const appointmentService = {
   // Get today's appointments
   getTodayAppointments: async (clinicId) => {
     const response = await apiClient.get(
-      `/api/v1/appointments/appointments/clinic/${clinicId}/today`
+      `/api/v1/appointments/clinic/${clinicId}/today`
     );
     return response.data;
   },
@@ -53,7 +48,7 @@ const appointmentService = {
   // Get pending appointments
   getPendingAppointments: async (clinicId) => {
     const response = await apiClient.get(
-      `/api/v1/appointments/appointments/clinic/${clinicId}/pending`
+      `/api/v1/appointments/clinic/${clinicId}/pending`
     );
     return response.data;
   },
@@ -61,7 +56,7 @@ const appointmentService = {
   // Reschedule appointment
   rescheduleAppointment: async (id, data) => {
     const response = await apiClient.put(
-      `/api/v1/appointments/appointments/${id}/reschedule`,
+      `/api/v1/appointments/${id}/reschedule`,
       data
     );
     return response.data;
@@ -70,7 +65,7 @@ const appointmentService = {
   // Confirm appointment
   confirmAppointment: async (id, data) => {
     const response = await apiClient.put(
-      `/api/v1/appointments/appointments/${id}/confirm`,
+      `/api/v1/appointments/${id}/confirm`,
       data
     );
     return response.data;
@@ -79,7 +74,7 @@ const appointmentService = {
   // Update appointment notes
   updateAppointmentNotes: async (id, data) => {
     const response = await apiClient.put(
-      `/api/v1/appointments/appointments/${id}/notes`,
+      `/api/v1/appointments/${id}/notes`,
       data
     );
     return response.data;
@@ -87,16 +82,14 @@ const appointmentService = {
 
   // Complete appointment
   completeAppointment: async (id) => {
-    const response = await apiClient.put(
-      `/api/v1/appointments/appointments/${id}/complete`
-    );
+    const response = await apiClient.put(`/api/v1/appointments/${id}/complete`);
     return response.data;
   },
 
   // Cancel appointment
   cancelAppointment: async (id, data) => {
     const response = await apiClient.put(
-      `/api/v1/appointments/appointments/${id}/cancel`,
+      `/api/v1/appointments/${id}/cancel`,
       data
     );
     return response.data;
@@ -104,17 +97,14 @@ const appointmentService = {
 
   // Update appointment status
   updateAppointmentStatus: async (id, data) => {
-    const response = await apiClient.put(
-      `/api/v1/appointments/appointments/${id}/status`,
-      data
-    );
+    const response = await apiClient.put(`/api/v1/appointments/${id}/status`, data);
     return response.data;
   },
 
   // Delete appointment
   deleteAppointment: async (id) => {
     const response = await apiClient.delete(
-      `/api/v1/appointments/appointments/${id}`
+      `/api/v1/appointments/${id}`
     );
     return response.data;
   },
@@ -122,7 +112,7 @@ const appointmentService = {
   // Get appointment count for patient
   getAppointmentCount: async (patientId) => {
     const response = await apiClient.get(
-      `/api/v1/appointments/appointments/patient/${patientId}/count`
+      `/api/v1/appointments/patient/${patientId}/count`
     );
     return response.data;
   },

--- a/src/api/services/patientService.js
+++ b/src/api/services/patientService.js
@@ -1,4 +1,13 @@
 import apiClient from "api/apiClient";
+import { sessionManager } from "platform/auth/sessionManager";
+
+const getCurrentUserId = () => {
+  const userId = sessionManager.hydrate()?.user?.id;
+  if (!userId) {
+    throw new Error("Current user is not available");
+  }
+  return userId;
+};
 
 /**
  * Patient Service
@@ -17,7 +26,7 @@ const patientService = {
    * @returns {Promise<Object>} Created patient profile
    */
   createPatientProfile: async (data) => {
-    const response = await apiClient.post("/api/v1/patients/patients", data);
+    const response = await apiClient.post("/api/v1/patients", data);
     return response.data;
   },
 
@@ -27,9 +36,7 @@ const patientService = {
    * @returns {Promise<Object>} Patient profile
    */
   getPatientProfile: async (patientId) => {
-    const response = await apiClient.get(
-      `/api/v1/patients/patients/${patientId}`
-    );
+    const response = await apiClient.get(`/api/v1/patients/${patientId}`);
     return response.data;
   },
 
@@ -40,7 +47,7 @@ const patientService = {
    */
   getPatientProfileByUserId: async (userId) => {
     const response = await apiClient.get(
-      `/api/v1/patients/patients/user/${userId}`
+      `/api/v1/patients/user/${userId}`
     );
     return response.data;
   },
@@ -52,7 +59,7 @@ const patientService = {
    */
   getPatientByNationalId: async (nationalId) => {
     const response = await apiClient.get(
-      `/api/v1/patients/patients/national-id/${nationalId}`
+      `/api/v1/patients/national-id/${nationalId}`
     );
     return response.data;
   },
@@ -65,7 +72,7 @@ const patientService = {
    */
   updatePatientProfile: async (patientId, data) => {
     const response = await apiClient.put(
-      `/api/v1/patients/patients/${patientId}`,
+      `/api/v1/patients/${patientId}`,
       data
     );
     return response.data;
@@ -78,7 +85,7 @@ const patientService = {
    */
   deletePatientProfile: async (patientId) => {
     const response = await apiClient.delete(
-      `/api/v1/patients/patients/${patientId}`
+      `/api/v1/patients/${patientId}`
     );
     return response.data;
   },
@@ -90,7 +97,7 @@ const patientService = {
    */
   deletePatientProfileByUserId: async (userId) => {
     const response = await apiClient.delete(
-      `/api/v1/patients/patients/user/${userId}`
+      `/api/v1/patients/user/${userId}`
     );
     return response.data;
   },
@@ -112,7 +119,7 @@ const patientService = {
    * @param {number} params.offset - Results offset
    * @returns {Promise<Object>} Search results
    */
-  searchPatients: async (params) => {
+  searchPatients: async (params = {}) => {
     const queryParams = new URLSearchParams();
 
     // Add all defined parameters
@@ -123,7 +130,7 @@ const patientService = {
     });
 
     const response = await apiClient.get(
-      `/api/v1/patients/patients/search?${queryParams.toString()}`
+      `/api/v1/patients/search?${queryParams.toString()}`
     );
     return response.data;
   },
@@ -133,9 +140,7 @@ const patientService = {
    * @returns {Promise<Object>} Demographics summary
    */
   getDemographicsSummary: async () => {
-    const response = await apiClient.get(
-      "/api/v1/patients/patients/demographics"
-    );
+    const response = await apiClient.get("/api/v1/patients/demographics");
     return response.data;
   },
 
@@ -144,8 +149,7 @@ const patientService = {
    * @returns {Promise<Object>} Patient profile
    */
   getCurrentPatientProfile: async () => {
-    const response = await apiClient.get("/api/v1/patients/patients/me");
-    return response.data;
+    return patientService.getPatientProfileByUserId(getCurrentUserId());
   },
 
   /**
@@ -154,8 +158,7 @@ const patientService = {
    * @returns {Promise<Object>} Created/updated patient profile
    */
   upsertPatientProfile: async (data) => {
-    const response = await apiClient.put("/api/v1/patients/patients/me", data);
-    return response.data;
+    return patientService.createPatientProfile(data);
   },
 
   /**

--- a/src/api/services/providerService.js
+++ b/src/api/services/providerService.js
@@ -1,9 +1,105 @@
 import apiClient from "../apiClient";
 
+const CLINIC_TYPE_ALIASES = {
+  private: "private_clinic",
+  public: "public_health_clinic",
+  community: "community_health_center",
+  mobile: "mobile_clinic",
+};
+
+const normalizeClinicPayload = (data = {}) => {
+  const { operating_hours, ...rest } = data;
+  const payload = {
+    ...rest,
+    clinic_type: CLINIC_TYPE_ALIASES[data.clinic_type] || data.clinic_type,
+    accepts_medical_aid: Boolean(data.accepts_medical_aid),
+  };
+
+  if (operating_hours && typeof operating_hours === "object") {
+    payload.operating_hours = operating_hours;
+  }
+
+  return payload;
+};
+
+const normalizeStaffPayload = (data = {}) => {
+  const payload = {
+    ...data,
+    staff_role: data.staff_role || data.role,
+    work_email: data.work_email || data.email,
+    work_phone: data.work_phone || data.phone_number,
+    employment_status: data.employment_status || data.status || "active",
+  };
+
+  delete payload.role;
+  delete payload.email;
+  delete payload.phone_number;
+  delete payload.status;
+  return payload;
+};
+
+const normalizeServicePayload = (data = {}) => ({
+  ...data,
+  cost_currency: data.cost_currency || "ZAR",
+  follow_up_required: Boolean(data.follow_up_required),
+  is_covered_by_medical_aid: Boolean(data.is_covered_by_medical_aid),
+  is_active: data.is_active !== undefined ? data.is_active : true,
+  requires_appointment:
+    data.requires_appointment !== undefined ? data.requires_appointment : true,
+  walk_in_allowed: Boolean(data.walk_in_allowed),
+});
+
+const normalizeStaff = (staff = {}) => ({
+  ...staff,
+  staff_id: staff.staff_id || staff.id,
+  role: staff.role || staff.staff_role,
+  email: staff.email || staff.work_email,
+  phone_number: staff.phone_number || staff.work_phone || staff.personal_phone,
+  status: staff.status || staff.employment_status || "active",
+});
+
+const normalizeService = (service = {}) => ({
+  ...service,
+  service_id: service.service_id || service.id,
+});
+
+const normalizeStaffList = (payload = {}) => ({
+  ...payload,
+  staff: (payload.staff || []).map(normalizeStaff),
+});
+
+const normalizeServiceList = (payload = {}) => ({
+  ...payload,
+  services: (payload.services || []).map(normalizeService),
+});
+
+const normalizeVerificationPayload = (dataOrUserId, notes) => {
+  if (typeof dataOrUserId === "object" && dataOrUserId !== null) {
+    return {
+      verified_by: dataOrUserId.verified_by,
+      notes:
+        dataOrUserId.notes ||
+        dataOrUserId.rejection_reason ||
+        dataOrUserId.status ||
+        "Clinic verification reviewed",
+      status: dataOrUserId.status || dataOrUserId.verification_status,
+    };
+  }
+
+  return {
+    verified_by: dataOrUserId,
+    notes: notes || "Clinic verified",
+    status: "verified",
+  };
+};
+
 const providerService = {
   // Clinic routes
   registerClinic: async (data) => {
-    const response = await apiClient.post("/api/v1/providers/clinics", data);
+    const response = await apiClient.post(
+      "/api/v1/providers/clinics",
+      normalizeClinicPayload(data)
+    );
     return response.data;
   },
 
@@ -29,9 +125,19 @@ const providerService = {
   },
 
   updateClinic: async (clinicId, data) => {
+    let existing = {};
+    try {
+      const response = await apiClient.get(
+        `/api/v1/providers/clinics/${clinicId}`
+      );
+      existing = response.data || {};
+    } catch {
+      existing = {};
+    }
+
     const response = await apiClient.put(
       `/api/v1/providers/clinics/${clinicId}`,
-      data
+      normalizeClinicPayload({ ...existing, ...data })
     );
     return response.data;
   },
@@ -43,39 +149,46 @@ const providerService = {
     return response.data;
   },
 
-  verifyClinic: async (clinicId, data) => {
+  verifyClinic: async (clinicId, data, notes) => {
+    const payload = normalizeVerificationPayload(data, notes);
     const response = await apiClient.put(
       `/api/v1/providers/clinics/${clinicId}/verify`,
-      data
+      {
+        verified_by: payload.verified_by,
+        notes: payload.notes,
+      }
     );
     return response.data;
   },
 
   updateVerifyClinic: async (clinicId, data) => {
-    const response = await apiClient.put(
-      `/api/v1/providers/clinics/${clinicId}/verification-status`,
-      data
-    );
-    return response.data;
+    const payload = normalizeVerificationPayload(data);
+    if (payload.status === "rejected") {
+      throw new Error("Clinic rejection is not supported by the backend API");
+    }
+    return providerService.verifyClinic(clinicId, payload);
   },
 
   // Staff routes
   registerStaff: async (data) => {
-    const response = await apiClient.post("/api/v1/providers/staff", data);
-    return response.data;
+    const response = await apiClient.post(
+      "/api/v1/providers/staff",
+      normalizeStaffPayload(data)
+    );
+    return normalizeStaff(response.data);
   },
 
   getStaff: async (staffId) => {
     const response = await apiClient.get(`/api/v1/providers/staff/${staffId}`);
-    return response.data;
+    return normalizeStaff(response.data);
   },
 
   updateStaff: async (staffId, data) => {
     const response = await apiClient.put(
       `/api/v1/providers/staff/${staffId}`,
-      data
+      normalizeStaffPayload(data)
     );
-    return response.data;
+    return normalizeStaff(response.data);
   },
 
   deleteStaff: async (staffId) => {
@@ -97,35 +210,38 @@ const providerService = {
     const response = await apiClient.get(
       `/api/v1/providers/clinics/${clinicId}/staff`
     );
-    return response.data;
+    return normalizeStaffList(response.data);
   },
 
   listActiveClinicStaff: async (clinicId) => {
     const response = await apiClient.get(
       `/api/v1/providers/clinics/${clinicId}/staff/active`
     );
-    return response.data;
+    return normalizeStaffList(response.data);
   },
 
   // Service routes
   registerService: async (data) => {
-    const response = await apiClient.post("/api/v1/providers/services", data);
-    return response.data;
+    const response = await apiClient.post(
+      "/api/v1/providers/services",
+      normalizeServicePayload(data)
+    );
+    return normalizeService(response.data);
   },
 
   getService: async (serviceId) => {
     const response = await apiClient.get(
       `/api/v1/providers/services/${serviceId}`
     );
-    return response.data;
+    return normalizeService(response.data);
   },
 
   updateService: async (serviceId, data) => {
     const response = await apiClient.put(
       `/api/v1/providers/services/${serviceId}`,
-      data
+      normalizeServicePayload(data)
     );
-    return response.data;
+    return normalizeService(response.data);
   },
 
   deleteService: async (serviceId) => {
@@ -147,7 +263,7 @@ const providerService = {
     const response = await apiClient.get(
       `/api/v1/providers/clinics/${clinicId}/services`
     );
-    return response.data;
+    return normalizeServiceList(response.data);
   },
 
   // Credential routes

--- a/src/hooks/__tests__/usePatient.test.jsx
+++ b/src/hooks/__tests__/usePatient.test.jsx
@@ -1,31 +1,75 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClientProvider } from "@tanstack/react-query";
-import { queryClient } from "platform/query/queryClient";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import patientService from "api/services/patientService";
 import { usePatient } from "../usePatient";
 
 jest.mock("api/services/patientService", () => ({
   __esModule: true,
   default: {
-    getCurrentPatientProfile: () => Promise.resolve({
-      id: "p1",
-      first_name: "Amina",
-      last_name: "Dube",
-    }),
+    getCurrentPatientProfile: jest.fn(),
+    getPatientProfileByUserId: jest.fn(),
+    upsertPatientProfile: jest.fn(),
     calculateProfileCompletion: () => 80,
   },
 }));
 
 describe("usePatient", () => {
-  it("hydrates patient state from a shared query", async () => {
-    const wrapper = ({ children }) => (
+  beforeEach(() => {
+    patientService.getCurrentPatientProfile.mockResolvedValue({
+      id: "p1",
+      first_name: "Amina",
+      last_name: "Dube",
+    });
+    patientService.getPatientProfileByUserId.mockResolvedValue({
+      id: "p1",
+      user_id: "u1",
+      first_name: "Amina",
+      last_name: "Dube",
+    });
+    patientService.upsertPatientProfile.mockImplementation((data) =>
+      Promise.resolve({ id: "p1", ...data })
+    );
+  });
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
+  };
 
-    const { result } = renderHook(() => usePatient(), { wrapper });
-    await result.current.getCurrentPatientProfile();
+  it("hydrates patient state from a shared query", async () => {
+    const { result } = renderHook(() => usePatient(), {
+      wrapper: createWrapper(),
+    });
+    await act(async () => {
+      await result.current.getCurrentPatientProfile();
+    });
 
     await waitFor(() => {
       expect(result.current.patient?.id).toBe("p1");
+    });
+  });
+
+  it("returns success wrappers for patient profile calls used by views", async () => {
+    const { result } = renderHook(() => usePatient(), {
+      wrapper: createWrapper(),
+    });
+    let response;
+    await act(async () => {
+      response = await result.current.getPatientProfileByUserId("u1");
+    });
+
+    expect(response).toEqual({
+      success: true,
+      data: {
+        id: "p1",
+        user_id: "u1",
+        first_name: "Amina",
+        last_name: "Dube",
+      },
     });
   });
 });

--- a/src/hooks/__tests__/useProvider.test.jsx
+++ b/src/hooks/__tests__/useProvider.test.jsx
@@ -1,28 +1,82 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import { QueryClientProvider } from "@tanstack/react-query";
-import { queryClient } from "platform/query/queryClient";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import providerService from "api/services/providerService";
 import { useProvider } from "../useProvider";
 
 jest.mock("api/services/providerService", () => ({
   __esModule: true,
   default: {
-    getMyClinic: () => Promise.resolve({
-      clinic: { id: "c1", name: "City Clinic" },
-    }),
+    getMyClinic: jest.fn(),
+    getClinics: jest.fn(),
+    listClinicStaff: jest.fn(),
+    getClinicService: jest.fn(),
   },
 }));
 
 describe("useProvider", () => {
-  it("hydrates clinic state from a shared query", async () => {
-    const wrapper = ({ children }) => (
+  beforeEach(() => {
+    providerService.getMyClinic.mockResolvedValue({
+      clinic: { id: "c1", name: "City Clinic" },
+    });
+    providerService.getClinics.mockResolvedValue({
+      clinics: [{ id: "c1", clinic_name: "City Clinic" }],
+      total: 1,
+    });
+    providerService.listClinicStaff.mockResolvedValue({
+      staff: [{ id: "s1", first_name: "Amina" }],
+      total: 1,
+    });
+    providerService.getClinicService.mockResolvedValue({
+      services: [{ id: "svc1", service_name: "Consultation" }],
+      total: 1,
+    });
+  });
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return ({ children }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
+  };
 
-    const { result } = renderHook(() => useProvider(), { wrapper });
-    await result.current.getMyClinic();
+  it("hydrates clinic state from a shared query", async () => {
+    const { result } = renderHook(() => useProvider(), {
+      wrapper: createWrapper(),
+    });
+    await act(async () => {
+      await result.current.getMyClinic();
+    });
 
     await waitFor(() => {
       expect(result.current.clinic?.id).toBe("c1");
+    });
+  });
+
+  it("hydrates clinic, staff, and service lists with view-compatible arrays", async () => {
+    const { result } = renderHook(() => useProvider(), {
+      wrapper: createWrapper(),
+    });
+
+    let clinics;
+    let staff;
+    let services;
+    await act(async () => {
+      clinics = await result.current.getClinics();
+      staff = await result.current.listClinicStaff("c1");
+      services = await result.current.getClinicService("c1");
+    });
+
+    expect(clinics.success).toBe(true);
+    expect(clinics.data.clinics).toHaveLength(1);
+    expect(staff).toEqual({
+      success: true,
+      data: [{ id: "s1", first_name: "Amina" }],
+    });
+    expect(services).toEqual({
+      success: true,
+      data: [{ id: "svc1", service_name: "Consultation" }],
     });
   });
 });

--- a/src/hooks/useAdmin.js
+++ b/src/hooks/useAdmin.js
@@ -1,429 +1,186 @@
-import adminService from "api/services/adminService";
 import { useCallback, useState } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQueryClient } from "@tanstack/react-query";
+import adminService from "api/services/adminService";
 import { queryKeys } from "platform/query/queryKeys";
 
-/**
- * Custom hook for admin operations
- * @returns {Object} Admin methods and state
- */
+const emptyPermissions = {
+  canManageUsers: false,
+  canManageClinics: false,
+  canManageContent: false,
+  canViewAnalytics: false,
+  canManageSystem: false,
+  adminLevel: null,
+  assignedRegions: [],
+};
+
+const getErrorMessage = (err, fallback) =>
+  err.response?.data?.error || err.message || fallback;
+
 export const useAdmin = () => {
   const queryClient = useQueryClient();
-
   const [loadingCount, setLoadingCount] = useState(0);
   const [error, setError] = useState(null);
   const [admin, setAdmin] = useState(null);
-  const [permissions, setPermissions] = useState({
-    canManageUsers: false,
-    canManageClinics: false,
-    canManageContent: false,
-    canViewAnalytics: false,
-    canManageSystem: false,
-    adminLevel: null,
-    assignedRegions: [],
-  });
+  const [permissions, setPermissions] = useState(emptyPermissions);
 
-  const startLoading = useCallback(() => setLoadingCount((c) => c + 1), []);
-  const stopLoading = useCallback(() => setLoadingCount((c) => Math.max(0, c - 1)), []);
-  const loading = loadingCount > 0;
+  const startLoading = useCallback(() => setLoadingCount((count) => count + 1), []);
+  const stopLoading = useCallback(
+    () => setLoadingCount((count) => Math.max(0, count - 1)),
+    []
+  );
 
-  // Query parameter states for useQuery hooks with enabled: false
-  const [activeAdminId, setActiveAdminId] = useState(null);
-  const [activeUserId, setActiveUserId] = useState(null);
-  const [activeSearchParams, setActiveSearchParams] = useState(null);
-  const [activePermission, setActivePermission] = useState(null);
-
-  // useQuery hooks with enabled: false (for cache registration only)
-  useQuery({
-    queryKey: [...queryKeys.admin.profile, activeAdminId],
-    queryFn: () => adminService.getSystemAdmin(activeAdminId),
-    enabled: false,
-  });
-
-  useQuery({
-    queryKey: [...queryKeys.admin.profile, "user", activeUserId],
-    queryFn: () => adminService.getSystemAdminByUserId(activeUserId),
-    enabled: false,
-  });
-
-  useQuery({
-    queryKey: queryKeys.admin.profile,
-    queryFn: () => adminService.getCurrentSystemAdminProfile(),
-    enabled: false,
-  });
-
-  useQuery({
-    queryKey: queryKeys.admin.permissions,
-    queryFn: () => adminService.getAdminPermissions(),
-    enabled: false,
-  });
-
-  useQuery({
-    queryKey: [...queryKeys.admin.users, activeSearchParams],
-    queryFn: () => adminService.searchSystemAdmins(activeSearchParams),
-    enabled: false,
-  });
-
-  useQuery({
-    queryKey: [...queryKeys.admin.permissions, activePermission],
-    queryFn: () => adminService.hasPermission(activePermission),
-    enabled: false,
-  });
-
-  // Mutations
-  const createSystemAdminMutation = useMutation({
-    mutationFn: (data) => adminService.createSystemAdmin(data),
-    onSuccess: async (data) => {
-      setAdmin(data);
-      try {
-        const newPermissions = await adminService.getAdminPermissions();
-        setPermissions(newPermissions);
-        queryClient.setQueryData(queryKeys.admin.permissions, newPermissions);
-      } catch (err) {
-        // Silently fail permissions update
-      }
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users });
-    },
-  });
-
-  const updateSystemAdminMutation = useMutation({
-    mutationFn: ({ adminId, data }) => adminService.updateSystemAdmin(adminId, data),
-    onSuccess: async (data) => {
-      setAdmin(data);
-      try {
-        const newPermissions = await adminService.getAdminPermissions();
-        setPermissions(newPermissions);
-        queryClient.setQueryData(queryKeys.admin.permissions, newPermissions);
-      } catch (err) {
-        // Silently fail permissions update
-      }
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users });
-    },
-  });
-
-  const deleteSystemAdminMutation = useMutation({
-    mutationFn: (adminId) => adminService.deleteSystemAdmin(adminId),
-    onSuccess: () => {
-      setAdmin(null);
-      setPermissions({
-        canManageUsers: false,
-        canManageClinics: false,
-        canManageContent: false,
-        canViewAnalytics: false,
-        canManageSystem: false,
-        adminLevel: null,
-        assignedRegions: [],
-      });
-      queryClient.removeQueries({ queryKey: queryKeys.admin.profile });
-      queryClient.removeQueries({ queryKey: queryKeys.admin.permissions });
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users });
-    },
-  });
-
-  const upsertSystemAdminProfileMutation = useMutation({
-    mutationFn: (data) => adminService.upsertSystemAdminProfile(data),
-    onSuccess: async (data) => {
-      setAdmin(data);
-      try {
-        const newPermissions = await adminService.getAdminPermissions();
-        setPermissions(newPermissions);
-        queryClient.setQueryData(queryKeys.admin.permissions, newPermissions);
-      } catch (err) {
-        // Silently fail permissions update
-      }
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.profile });
-      queryClient.invalidateQueries({ queryKey: queryKeys.admin.users });
-    },
-  });
-
-  // Create system admin
-  const createSystemAdmin = async (data) => {
-    startLoading();
-    setError(null);
-    try {
-      const validation = adminService.validateSystemAdmin(data);
-      if (!validation.isValid) {
-        throw new Error(
-          "Validation failed: " + JSON.stringify(validation.errors)
+  const setAdminState = useCallback(
+    (profile) => {
+      setAdmin(profile || null);
+      const normalized = adminService.normalizePermissionPayload(profile);
+      setPermissions(normalized);
+      if (profile) {
+        queryClient.setQueryData(
+          [...queryKeys.admin.profile, "user", profile.user_id],
+          profile
         );
+        queryClient.setQueryData(queryKeys.admin.current, profile);
+        queryClient.setQueryData(queryKeys.admin.permissions, normalized);
       }
+    },
+    [queryClient]
+  );
 
-      const response = await createSystemAdminMutation.mutateAsync(data);
-      stopLoading();
-      return { success: true, data: response };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.error ||
-        err.message ||
-        "Failed to create system admin";
-      setError(errorMessage);
-      stopLoading();
-      return { success: false, error: errorMessage };
-    }
-  };
-
-  // Get system admin by ID
-  const getSystemAdmin = async (adminId) => {
-    startLoading();
-    setError(null);
-    try {
-      const response = await queryClient.fetchQuery({
-        queryKey: [...queryKeys.admin.profile, adminId],
-        queryFn: () => adminService.getSystemAdmin(adminId),
-      });
-      setAdmin(response);
-      setActiveAdminId(adminId);
-      stopLoading();
-      return { success: true, data: response };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.error || "Failed to load system admin";
-      setError(errorMessage);
-      stopLoading();
-      return { success: false, error: errorMessage };
-    }
-  };
-
-  // Get system admin by user ID
-  const getSystemAdminByUserId = async (userId) => {
-    startLoading();
-    setError(null);
-    try {
-      const response = await queryClient.fetchQuery({
-        queryKey: [...queryKeys.admin.profile, "user", userId],
-        queryFn: () => adminService.getSystemAdminByUserId(userId),
-      });
-      setAdmin(response);
-      setActiveUserId(userId);
-      stopLoading();
-      return { success: true, data: response };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.error || "Failed to load system admin";
-      setError(errorMessage);
-      stopLoading();
-      return { success: false, error: errorMessage };
-    }
-  };
-
-  // Get current system admin profile
-  const getCurrentSystemAdminProfile = async () => {
-    startLoading();
-    setError(null);
-    try {
-      const response = await queryClient.fetchQuery({
-        queryKey: queryKeys.admin.profile,
-        queryFn: () => adminService.getCurrentSystemAdminProfile(),
-      });
-      setAdmin(response);
-
-      // Update permissions
+  const run = useCallback(
+    async (fn, fallback) => {
+      startLoading();
+      setError(null);
       try {
-        const newPermissions = await adminService.getAdminPermissions();
-        setPermissions(newPermissions);
-        queryClient.setQueryData(queryKeys.admin.permissions, newPermissions);
+        const data = await fn();
+        stopLoading();
+        return { success: true, data };
       } catch (err) {
-        // Silently fail permissions update
+        const message = getErrorMessage(err, fallback);
+        setError(message);
+        stopLoading();
+        return { success: false, error: message };
       }
+    },
+    [startLoading, stopLoading]
+  );
 
-      stopLoading();
-      return { success: true, data: response };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.error ||
-        err.message ||
-        "Failed to load system admin profile";
-      setError(errorMessage);
-      stopLoading();
-      // Don't set admin to null here, as 404 is expected for non-admin users
-      return { success: false, error: errorMessage };
-    }
-  };
+  const createSystemAdmin = useCallback(
+    async (data) =>
+      run(async () => {
+        const validation = adminService.validateSystemAdmin(data);
+        if (!validation.isValid) {
+          throw new Error(
+            `Validation failed: ${JSON.stringify(validation.errors)}`
+          );
+        }
 
-  // Update system admin
-  const updateSystemAdmin = async (adminId, data) => {
-    startLoading();
-    setError(null);
-    try {
-      const validation = adminService.validateSystemAdmin(data);
-      if (!validation.isValid) {
-        throw new Error(
-          "Validation failed: " + JSON.stringify(validation.errors)
-        );
-      }
+        const response = await adminService.createSystemAdmin(data);
+        setAdminState(response);
+        queryClient.invalidateQueries({ queryKey: queryKeys.admin.users });
+        return response;
+      }, "Failed to create system admin"),
+    [queryClient, run, setAdminState]
+  );
 
-      const response = await updateSystemAdminMutation.mutateAsync({ adminId, data });
-      stopLoading();
-      return { success: true, data: response };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.error || "Failed to update system admin";
-      setError(errorMessage);
-      stopLoading();
-      return { success: false, error: errorMessage };
-    }
-  };
+  const getSystemAdminByUserId = useCallback(
+    async (userId) =>
+      run(async () => {
+        const response = await queryClient.fetchQuery({
+          queryKey: [...queryKeys.admin.profile, "user", userId],
+          queryFn: () => adminService.getSystemAdminByUserId(userId),
+        });
+        setAdminState(response);
+        return response;
+      }, "Failed to load system admin"),
+    [queryClient, run, setAdminState]
+  );
 
-  // Delete system admin
-  const deleteSystemAdmin = async (adminId) => {
-    startLoading();
-    setError(null);
-    try {
-      await deleteSystemAdminMutation.mutateAsync(adminId);
-      stopLoading();
-      return { success: true };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.error || "Failed to delete system admin";
-      setError(errorMessage);
-      stopLoading();
-      return { success: false, error: errorMessage };
-    }
-  };
+  const getCurrentSystemAdminProfile = useCallback(
+    async () =>
+      run(async () => {
+        const response = await queryClient.fetchQuery({
+          queryKey: queryKeys.admin.current,
+          queryFn: adminService.getCurrentSystemAdminProfile,
+        });
+        setAdminState(response);
+        return response;
+      }, "Failed to load system admin profile"),
+    [queryClient, run, setAdminState]
+  );
 
-  // Search system admins
-  const searchSystemAdmins = async (params) => {
-    startLoading();
-    setError(null);
-    try {
-      const response = await queryClient.fetchQuery({
-        queryKey: [...queryKeys.admin.users, params],
-        queryFn: () => adminService.searchSystemAdmins(params),
-      });
-      setActiveSearchParams(params);
-      stopLoading();
-      return { success: true, data: response };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.error || "Failed to search system admins";
-      setError(errorMessage);
-      stopLoading();
-      return { success: false, error: errorMessage };
-    }
-  };
+  const getPermissions = useCallback(
+    async () =>
+      run(async () => {
+        const response = await adminService.getAdminPermissions();
+        setPermissions(response);
+        queryClient.setQueryData(queryKeys.admin.permissions, response);
+        return response;
+      }, "Failed to load permissions"),
+    [queryClient, run]
+  );
 
-  // Create or update system admin (upsert)
-  const upsertSystemAdminProfile = async (data) => {
-    startLoading();
-    setError(null);
-    try {
-      const validation = adminService.validateSystemAdmin(data);
-      if (!validation.isValid) {
-        throw new Error(
-          "Validation failed: " + JSON.stringify(validation.errors)
-        );
-      }
+  const hasPermission = useCallback(
+    async (permission) => {
+      const source =
+        admin || (await adminService.getCurrentSystemAdminProfile().catch(() => null));
+      const normalized = adminService.normalizePermissionPayload(source);
+      const permissionMap = {
+        manage_users: normalized.canManageUsers,
+        manage_clinics: normalized.canManageClinics,
+        manage_content: normalized.canManageContent,
+        view_analytics: normalized.canViewAnalytics,
+        manage_system: normalized.canManageSystem,
+      };
+      return Boolean(permissionMap[permission]);
+    },
+    [admin]
+  );
 
-      const response = await upsertSystemAdminProfileMutation.mutateAsync(data);
-      stopLoading();
-      return { success: true, data: response };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.error ||
-        err.message ||
-        "Failed to save system admin profile";
-      setError(errorMessage);
-      stopLoading();
-      return { success: false, error: errorMessage };
-    }
-  };
+  const unsupported = useCallback(
+    async (operation) => ({
+      success: false,
+      error: `${operation} is not supported by the backend admin API`,
+    }),
+    []
+  );
 
-  // Get permissions
-  const getPermissions = async () => {
-    startLoading();
-    setError(null);
-    try {
-      const perms = await queryClient.fetchQuery({
-        queryKey: queryKeys.admin.permissions,
-        queryFn: () => adminService.getAdminPermissions(),
-      });
-      setPermissions(perms);
-      stopLoading();
-      return { success: true, data: perms };
-    } catch (err) {
-      const errorMessage =
-        err.response?.data?.error || "Failed to load permissions";
-      setError(errorMessage);
-      stopLoading();
-      return { success: false, error: errorMessage };
-    }
-  };
+  const validateAdminData = useCallback(
+    (data) => adminService.validateSystemAdmin(data),
+    []
+  );
 
-  // Check permission
-  const hasPermission = async (permission) => {
-    try {
-      const result = await queryClient.fetchQuery({
-        queryKey: [...queryKeys.admin.permissions, permission],
-        queryFn: () => adminService.hasPermission(permission),
-      });
-      setActivePermission(permission);
-      return result;
-    } catch (err) {
-      console.error("Failed to check permission:", err);
-      return false;
-    }
-  };
+  const getAdminLevelDisplayName = useCallback(
+    (adminLevel) => adminService.getAdminLevelDisplayName(adminLevel),
+    []
+  );
 
-  // Validate admin data
-  const validateAdminData = useCallback((data) => {
-    return adminService.validateSystemAdmin(data);
-  }, []);
+  const getAllAdminLevels = useCallback(
+    () => adminService.getAllAdminLevels(),
+    []
+  );
 
-  // Get admin level display name
-  const getAdminLevelDisplayName = useCallback((adminLevel) => {
-    return adminService.getAdminLevelDisplayName(adminLevel);
-  }, []);
-
-  // Get all admin levels
-  const getAllAdminLevels = useCallback(() => {
-    return adminService.getAllAdminLevels();
-  }, []);
-
-  // Clear admin state
   const clearAdmin = useCallback(() => {
     setAdmin(null);
-    setPermissions({
-      canManageUsers: false,
-      canManageClinics: false,
-      canManageContent: false,
-      canViewAnalytics: false,
-      canManageSystem: false,
-      adminLevel: null,
-      assignedRegions: [],
-    });
+    setPermissions(emptyPermissions);
     setError(null);
-    setActiveAdminId(null);
-    setActiveUserId(null);
-    setActiveSearchParams(null);
-    setActivePermission(null);
-    createSystemAdminMutation.reset();
-    updateSystemAdminMutation.reset();
-    deleteSystemAdminMutation.reset();
-    upsertSystemAdminProfileMutation.reset();
-  }, [createSystemAdminMutation, updateSystemAdminMutation, deleteSystemAdminMutation, upsertSystemAdminProfileMutation]);
+    queryClient.removeQueries({ queryKey: queryKeys.admin.current });
+    queryClient.removeQueries({ queryKey: queryKeys.admin.permissions });
+  }, [queryClient]);
 
-  // Clear error
-  const clearError = useCallback(() => {
-    setError(null);
-    createSystemAdminMutation.reset();
-    updateSystemAdminMutation.reset();
-    deleteSystemAdminMutation.reset();
-    upsertSystemAdminProfileMutation.reset();
-  }, [createSystemAdminMutation, updateSystemAdminMutation, deleteSystemAdminMutation, upsertSystemAdminProfileMutation]);
-
-  // REMOVED: Auto-load useEffect that was causing infinite loops
-  // Components should manually call getCurrentSystemAdminProfile when needed
+  const clearError = useCallback(() => setError(null), []);
 
   return {
-    // Methods
     createSystemAdmin,
-    getSystemAdmin,
+    getSystemAdmin: (adminId) =>
+      unsupported(`Loading system admin by profile ID ${adminId}`),
     getSystemAdminByUserId,
     getCurrentSystemAdminProfile,
-    updateSystemAdmin,
-    deleteSystemAdmin,
-    searchSystemAdmins,
-    upsertSystemAdminProfile,
+    updateSystemAdmin: (adminId) =>
+      unsupported(`Updating system admin by profile ID ${adminId}`),
+    deleteSystemAdmin: (adminId) =>
+      unsupported(`Deleting system admin by profile ID ${adminId}`),
+    searchSystemAdmins: () => unsupported("Searching system admins"),
+    upsertSystemAdminProfile: createSystemAdmin,
     getPermissions,
     hasPermission,
     validateAdminData,
@@ -431,15 +188,11 @@ export const useAdmin = () => {
     getAllAdminLevels,
     clearAdmin,
     clearError,
-
-    // State
-    loading,
+    loading: loadingCount > 0,
     error,
     admin,
     permissions,
-
-    // Derived state
-    isAdmin: !!admin,
+    isAdmin: Boolean(admin),
     isSuperAdmin: permissions.adminLevel === "super_admin",
     canManageUsers: permissions.canManageUsers,
     canManageClinics: permissions.canManageClinics,

--- a/src/hooks/usePatient.js
+++ b/src/hooks/usePatient.js
@@ -1,29 +1,168 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import patientService from "api/services/patientService";
 import { queryKeys } from "platform/query/queryKeys";
 
-export const usePatient = () => {
-  const client = useQueryClient();
-  const profileQuery = useQuery({
-    queryKey: queryKeys.patient.current,
-    queryFn: patientService.getCurrentPatientProfile,
-    enabled: false,
-  });
+const getErrorMessage = (err, fallback) =>
+  err.response?.data?.error || err.message || fallback;
 
-  const upsertMutation = useMutation({
-    mutationFn: patientService.upsertPatientProfile,
-    onSuccess: (data) => {
-      client.setQueryData(queryKeys.patient.current, data);
+export const usePatient = () => {
+  const queryClient = useQueryClient();
+  const [patient, setPatient] = useState(null);
+  const [loadingCount, setLoadingCount] = useState(0);
+  const [error, setError] = useState(null);
+
+  const startLoading = useCallback(() => setLoadingCount((count) => count + 1), []);
+  const stopLoading = useCallback(
+    () => setLoadingCount((count) => Math.max(0, count - 1)),
+    []
+  );
+
+  const setPatientCache = useCallback(
+    (profile) => {
+      setPatient(profile || null);
+      if (profile) {
+        queryClient.setQueryData(queryKeys.patient.current, profile);
+        queryClient.setQueryData(queryKeys.patient.profile(profile.id), profile);
+        queryClient.setQueryData(queryKeys.patient.byUser(profile.user_id), profile);
+      }
     },
-  });
+    [queryClient]
+  );
+
+  const run = useCallback(
+    async (fn, fallback) => {
+      startLoading();
+      setError(null);
+      try {
+        const data = await fn();
+        stopLoading();
+        return { success: true, data };
+      } catch (err) {
+        const message = getErrorMessage(err, fallback);
+        setError(message);
+        stopLoading();
+        return { success: false, error: message };
+      }
+    },
+    [startLoading, stopLoading]
+  );
+
+  const createPatientProfile = useCallback(
+    async (data) =>
+      run(async () => {
+        const response = await patientService.createPatientProfile(data);
+        setPatientCache(response);
+        return response;
+      }, "Failed to create patient profile"),
+    [run, setPatientCache]
+  );
+
+  const getPatientProfile = useCallback(
+    async (patientId) =>
+      run(async () => {
+        const response = await patientService.getPatientProfile(patientId);
+        setPatientCache(response);
+        return response;
+      }, "Failed to load patient profile"),
+    [run, setPatientCache]
+  );
+
+  const getPatientProfileByUserId = useCallback(
+    async (userId) =>
+      run(async () => {
+        const response = await patientService.getPatientProfileByUserId(userId);
+        setPatientCache(response);
+        return response;
+      }, "Failed to load patient profile"),
+    [run, setPatientCache]
+  );
+
+  const getCurrentPatientProfile = useCallback(
+    async () =>
+      run(async () => {
+        const response = await patientService.getCurrentPatientProfile();
+        setPatientCache(response);
+        return response;
+      }, "Failed to load patient profile"),
+    [run, setPatientCache]
+  );
+
+  const updatePatientProfile = useCallback(
+    async (patientId, data) =>
+      run(async () => {
+        const response = await patientService.updatePatientProfile(patientId, data);
+        setPatientCache(response);
+        return response;
+      }, "Failed to update patient profile"),
+    [run, setPatientCache]
+  );
+
+  const deletePatientProfile = useCallback(
+    async (patientId) =>
+      run(async () => {
+        const response = await patientService.deletePatientProfile(patientId);
+        setPatient(null);
+        queryClient.invalidateQueries({ queryKey: queryKeys.patient.current });
+        return response;
+      }, "Failed to delete patient profile"),
+    [queryClient, run]
+  );
+
+  const upsertPatientProfile = useCallback(
+    async (data) =>
+      run(async () => {
+        const response = await patientService.upsertPatientProfile(data);
+        setPatientCache(response);
+        return response;
+      }, "Failed to save patient profile"),
+    [run, setPatientCache]
+  );
+
+  const searchPatients = useCallback(
+    async (params = {}) =>
+      run(async () => {
+        const response = await patientService.searchPatients(params);
+        queryClient.setQueryData(queryKeys.patient.search(params), response);
+        return response;
+      }, "Failed to search patients"),
+    [queryClient, run]
+  );
+
+  const getDemographicsSummary = useCallback(
+    async () =>
+      run(async () => {
+        const response = await patientService.getDemographicsSummary();
+        queryClient.setQueryData(["patient", "demographics"], response);
+        return response;
+      }, "Failed to load demographics"),
+    [queryClient, run]
+  );
+
+  const clearPatientState = useCallback(() => {
+    setPatient(null);
+    setError(null);
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
 
   return {
-    getCurrentPatientProfile: () => profileQuery.refetch(),
-    upsertPatientProfile: upsertMutation.mutateAsync,
-    patient: profileQuery.data ?? null,
-    profileCompletion: patientService.calculateProfileCompletion(profileQuery.data),
-    loading: profileQuery.isFetching || upsertMutation.isPending,
-    error: profileQuery.error?.message || upsertMutation.error?.message || null,
-    hasPatient: Boolean(profileQuery.data),
+    createPatientProfile,
+    getPatientProfile,
+    getPatientProfileByUserId,
+    getCurrentPatientProfile,
+    updatePatientProfile,
+    deletePatientProfile,
+    upsertPatientProfile,
+    searchPatients,
+    getDemographicsSummary,
+    clearPatientState,
+    clearError,
+    validatePatientProfile: patientService.validatePatientProfile,
+    patient,
+    profileCompletion: patientService.calculateProfileCompletion(patient),
+    loading: loadingCount > 0,
+    error,
+    hasPatient: Boolean(patient),
   };
 };

--- a/src/hooks/useProvider.js
+++ b/src/hooks/useProvider.js
@@ -1,18 +1,372 @@
-import { useQuery } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import providerService from "api/services/providerService";
 import { queryKeys } from "platform/query/queryKeys";
 
+const getErrorMessage = (err, fallback) =>
+  err.response?.data?.error || err.message || fallback;
+
+const unwrapClinic = (payload) => payload?.clinic || payload || null;
+const unwrapClinics = (payload) => payload?.clinics || [];
+const unwrapStaff = (payload) => payload?.staff || [];
+const unwrapServices = (payload) => payload?.services || [];
+
 export const useProvider = () => {
-  const clinicQuery = useQuery({
-    queryKey: queryKeys.provider.clinic,
-    queryFn: providerService.getMyClinic,
-    enabled: false,
-  });
+  const queryClient = useQueryClient();
+  const [clinic, setClinic] = useState(null);
+  const [clinics, setClinics] = useState([]);
+  const [staffList, setStaffList] = useState([]);
+  const [serviceList, setServiceList] = useState([]);
+  const [loadingCount, setLoadingCount] = useState(0);
+  const [error, setError] = useState(null);
+
+  const startLoading = useCallback(() => setLoadingCount((count) => count + 1), []);
+  const stopLoading = useCallback(
+    () => setLoadingCount((count) => Math.max(0, count - 1)),
+    []
+  );
+
+  const run = useCallback(
+    async (fn, fallback) => {
+      startLoading();
+      setError(null);
+      try {
+        const data = await fn();
+        stopLoading();
+        return { success: true, data };
+      } catch (err) {
+        const message = getErrorMessage(err, fallback);
+        setError(message);
+        stopLoading();
+        return { success: false, error: message };
+      }
+    },
+    [startLoading, stopLoading]
+  );
+
+  const getMyClinic = useCallback(
+    async () =>
+      run(async () => {
+        const response = await providerService.getMyClinic();
+        const currentClinic = unwrapClinic(response);
+        setClinic(currentClinic);
+        queryClient.setQueryData(queryKeys.provider.clinic, response);
+        return response;
+      }, "Failed to load clinic"),
+    [queryClient, run]
+  );
+
+  const getClinics = useCallback(
+    async () =>
+      run(async () => {
+        const response = await providerService.getClinics();
+        setClinics(unwrapClinics(response));
+        queryClient.setQueryData(queryKeys.provider.clinics, response);
+        return response;
+      }, "Failed to load clinics"),
+    [queryClient, run]
+  );
+
+  const getClinic = useCallback(
+    async (clinicId) =>
+      run(async () => {
+        const response = await providerService.getClinic(clinicId);
+        setClinic(response);
+        queryClient.setQueryData([...queryKeys.provider.clinic, clinicId], response);
+        return response;
+      }, "Failed to load clinic"),
+    [queryClient, run]
+  );
+
+  const registerClinic = useCallback(
+    async (data) =>
+      run(async () => {
+        const response = await providerService.registerClinic(data);
+        setClinic(response);
+        setClinics((items) => [response, ...items.filter((item) => item.id !== response.id)]);
+        queryClient.invalidateQueries({ queryKey: queryKeys.provider.clinics });
+        return response;
+      }, "Failed to register clinic"),
+    [queryClient, run]
+  );
+
+  const updateClinic = useCallback(
+    async (clinicId, data) =>
+      run(async () => {
+        const response = await providerService.updateClinic(clinicId, data);
+        setClinic(response);
+        setClinics((items) =>
+          items.map((item) => (item.id === clinicId ? response : item))
+        );
+        queryClient.invalidateQueries({ queryKey: queryKeys.provider.clinics });
+        return response;
+      }, "Failed to update clinic"),
+    [queryClient, run]
+  );
+
+  const deleteClinic = useCallback(
+    async (clinicId) =>
+      run(async () => {
+        const response = await providerService.deleteClinic(clinicId);
+        setClinics((items) => items.filter((item) => item.id !== clinicId));
+        if (clinic?.id === clinicId) setClinic(null);
+        queryClient.invalidateQueries({ queryKey: queryKeys.provider.clinics });
+        return response;
+      }, "Failed to delete clinic"),
+    [clinic?.id, queryClient, run]
+  );
+
+  const markClinicVerified = useCallback((clinicId) => {
+    setClinics((items) =>
+      items.map((item) =>
+        item.id === clinicId
+          ? { ...item, is_verified: true, verification_status: "verified" }
+          : item
+      )
+    );
+    setClinic((item) =>
+      item?.id === clinicId
+        ? { ...item, is_verified: true, verification_status: "verified" }
+        : item
+    );
+  }, []);
+
+  const verifyClinic = useCallback(
+    async (clinicId, data, notes) =>
+      run(async () => {
+        const response = await providerService.verifyClinic(clinicId, data, notes);
+        markClinicVerified(clinicId);
+        queryClient.invalidateQueries({ queryKey: queryKeys.provider.clinics });
+        return response;
+      }, "Failed to verify clinic"),
+    [markClinicVerified, queryClient, run]
+  );
+
+  const updateVerifyClinic = useCallback(
+    async (clinicId, data) =>
+      run(async () => {
+        const response = await providerService.updateVerifyClinic(clinicId, data);
+        markClinicVerified(clinicId);
+        queryClient.invalidateQueries({ queryKey: queryKeys.provider.clinics });
+        return response;
+      }, "Failed to update clinic verification"),
+    [markClinicVerified, queryClient, run]
+  );
+
+  const listClinicStaff = useCallback(
+    async (clinicId) =>
+      run(async () => {
+        const response = await providerService.listClinicStaff(clinicId);
+        const list = unwrapStaff(response);
+        setStaffList(list);
+        queryClient.setQueryData(queryKeys.provider.staff(clinicId), response);
+        return list;
+      }, "Failed to load clinic staff"),
+    [queryClient, run]
+  );
+
+  const listActiveClinicStaff = useCallback(
+    async (clinicId) =>
+      run(async () => {
+        const response = await providerService.listActiveClinicStaff(clinicId);
+        const list = unwrapStaff(response);
+        setStaffList(list);
+        queryClient.setQueryData(queryKeys.provider.activeStaff(clinicId), response);
+        return list;
+      }, "Failed to load active clinic staff"),
+    [queryClient, run]
+  );
+
+  const registerStaff = useCallback(
+    async (data) =>
+      run(async () => {
+        const response = await providerService.registerStaff(data);
+        setStaffList((items) => [response, ...items.filter((item) => item.id !== response.id)]);
+        return response;
+      }, "Failed to register staff"),
+    [run]
+  );
+
+  const getStaff = useCallback(
+    async (staffId) =>
+      run(() => providerService.getStaff(staffId), "Failed to load staff"),
+    [run]
+  );
+
+  const updateStaff = useCallback(
+    async (staffId, data) =>
+      run(async () => {
+        const response = await providerService.updateStaff(staffId, data);
+        setStaffList((items) =>
+          items.map((item) =>
+            item.id === staffId || item.staff_id === staffId ? response : item
+          )
+        );
+        return response;
+      }, "Failed to update staff"),
+    [run]
+  );
+
+  const deleteStaff = useCallback(
+    async (staffId) =>
+      run(async () => {
+        const response = await providerService.deleteStaff(staffId);
+        setStaffList((items) =>
+          items.filter((item) => item.id !== staffId && item.staff_id !== staffId)
+        );
+        return response;
+      }, "Failed to delete staff"),
+    [run]
+  );
+
+  const checkStaffStatus = useCallback(
+    async (staffId) =>
+      run(
+        () => providerService.checkStaffStatus(staffId),
+        "Failed to check staff status"
+      ),
+    [run]
+  );
+
+  const getClinicService = useCallback(
+    async (clinicId) =>
+      run(async () => {
+        const response = await providerService.getClinicService(clinicId);
+        const list = unwrapServices(response);
+        setServiceList(list);
+        queryClient.setQueryData(queryKeys.provider.services(clinicId), response);
+        return list;
+      }, "Failed to load clinic services"),
+    [queryClient, run]
+  );
+
+  const registerService = useCallback(
+    async (data) =>
+      run(async () => {
+        const response = await providerService.registerService(data);
+        setServiceList((items) => [
+          response,
+          ...items.filter((item) => item.id !== response.id),
+        ]);
+        return response;
+      }, "Failed to register service"),
+    [run]
+  );
+
+  const getService = useCallback(
+    async (serviceId) =>
+      run(() => providerService.getService(serviceId), "Failed to load service"),
+    [run]
+  );
+
+  const updateService = useCallback(
+    async (serviceId, data) =>
+      run(async () => {
+        const response = await providerService.updateService(serviceId, data);
+        setServiceList((items) =>
+          items.map((item) =>
+            item.id === serviceId || item.service_id === serviceId ? response : item
+          )
+        );
+        return response;
+      }, "Failed to update service"),
+    [run]
+  );
+
+  const deleteService = useCallback(
+    async (serviceId) =>
+      run(async () => {
+        const response = await providerService.deleteService(serviceId);
+        setServiceList((items) =>
+          items.filter(
+            (item) => item.id !== serviceId && item.service_id !== serviceId
+          )
+        );
+        return response;
+      }, "Failed to delete service"),
+    [run]
+  );
+
+  const checkServiceExists = useCallback(
+    async (serviceId) =>
+      run(
+        () => providerService.checkServiceExists(serviceId),
+        "Failed to check service"
+      ),
+    [run]
+  );
+
+  const registerCredential = useCallback(
+    async (data) =>
+      run(
+        () => providerService.registerCredential(data),
+        "Failed to register credential"
+      ),
+    [run]
+  );
+
+  const deleteCredential = useCallback(
+    async (credentialId) =>
+      run(
+        () => providerService.deleteCredential(credentialId),
+        "Failed to delete credential"
+      ),
+    [run]
+  );
+
+  const getStaffCredential = useCallback(
+    async (staffId) =>
+      run(
+        () => providerService.getStaffCredential(staffId),
+        "Failed to load staff credentials"
+      ),
+    [run]
+  );
+
+  const clearProviderState = useCallback(() => {
+    setClinic(null);
+    setClinics([]);
+    setStaffList([]);
+    setServiceList([]);
+    setError(null);
+  }, []);
+
+  const clearError = useCallback(() => setError(null), []);
 
   return {
-    getMyClinic: () => clinicQuery.refetch(),
-    clinic: clinicQuery.data?.clinic || clinicQuery.data || null,
-    loading: clinicQuery.isFetching,
-    error: clinicQuery.error?.message || null,
+    getMyClinic,
+    getClinics,
+    getClinic,
+    registerClinic,
+    updateClinic,
+    deleteClinic,
+    verifyClinic,
+    updateVerifyClinic,
+    registerStaff,
+    getStaff,
+    updateStaff,
+    deleteStaff,
+    checkStaffStatus,
+    listClinicStaff,
+    listActiveClinicStaff,
+    getClinicService,
+    registerService,
+    getService,
+    updateService,
+    deleteService,
+    checkServiceExists,
+    registerCredential,
+    deleteCredential,
+    getStaffCredential,
+    clearProviderState,
+    clearError,
+    clinic,
+    clinics,
+    staffList,
+    staffTotal: staffList.length,
+    serviceList,
+    serviceTotal: serviceList.length,
+    loading: loadingCount > 0,
+    error,
   };
 };

--- a/src/platform/query/queryKeys.js
+++ b/src/platform/query/queryKeys.js
@@ -1,12 +1,22 @@
 export const queryKeys = {
   patient: {
     current: ["patient", "current"],
+    profile: (id) => ["patient", "profile", id],
+    byUser: (userId) => ["patient", "user", userId],
+    search: (params) => ["patient", "search", params],
   },
   provider: {
     clinic: ["provider", "clinic"],
+    clinics: ["provider", "clinics"],
+    staff: (clinicId) => ["provider", "clinic", clinicId, "staff"],
+    activeStaff: (clinicId) => ["provider", "clinic", clinicId, "staff", "active"],
+    services: (clinicId) => ["provider", "clinic", clinicId, "services"],
   },
   admin: {
     current: ["admin", "current"],
+    profile: ["admin", "profile"],
+    permissions: ["admin", "permissions"],
+    users: ["admin", "users"],
   },
   staff: {
     list: ["staff", "list"],

--- a/src/test/handlers/patient.js
+++ b/src/test/handlers/patient.js
@@ -6,7 +6,7 @@ export const createPatientHandlers = () => {
 
   return {
     handlers: [
-      rest.get("*/api/v1/patients/patients/me", (req, res, ctx) => {
+      rest.get("*/api/v1/patients/user/:userId", (req, res, ctx) => {
         if (shouldReturn401) {
           return res(
             ctx.status(401),

--- a/src/views/admin/clinic-verification/index.jsx
+++ b/src/views/admin/clinic-verification/index.jsx
@@ -177,11 +177,12 @@ const ClinicVerification = () => {
     if (!selectedClinic || !currentUser) return;
 
     setProcessingAction(true);
-    const result = await verifyClinic(
-      selectedClinic.id,
-      currentUser.id,
-      "verified"
-    );
+    const result = await verifyClinic(selectedClinic.id, {
+      verified_by: currentUser.id,
+      notes: `Clinic approved by ${currentUser.first_name || ""} ${
+        currentUser.last_name || ""
+      } on ${new Date().toLocaleDateString()}`,
+    });
 
     if (result.success) {
       showToast(

--- a/src/views/admin/components/RegistrationQueue.jsx
+++ b/src/views/admin/components/RegistrationQueue.jsx
@@ -92,7 +92,6 @@ const RegistrationQueue = ({ onApprove, onReject, onViewAll }) => {
   };
 
   const processApproval = async () => {
-    // Call verifyClinic to mark as verified
     const result = await verifyClinic(selectedClinic.id, {
       verified_by: currentUser.id,
       notes: `Clinic approved by ${currentUser.first_name || ""} ${
@@ -101,29 +100,16 @@ const RegistrationQueue = ({ onApprove, onReject, onViewAll }) => {
     });
 
     if (result.success) {
-      // Update verification status to "verified"
-      const statusResult = await updateVerifyClinic(selectedClinic.id, {
-        status: "verified",
-      });
+      toast.success(
+        `${selectedClinic.clinic_name} has been approved successfully`
+      );
 
-      if (statusResult.success) {
-        toast.success(
-          `${selectedClinic.clinic_name} has been approved successfully`
-        );
+      setPendingClinics((prev) =>
+        prev.filter((c) => c.id !== selectedClinic.id)
+      );
 
-        // Remove clinic from pending list
-        setPendingClinics((prev) =>
-          prev.filter((c) => c.id !== selectedClinic.id)
-        );
-
-        // Call parent callback if provided
-        if (onApprove) {
-          onApprove(selectedClinic);
-        }
-      } else {
-        toast.error(
-          statusResult.error || "Failed to update verification status"
-        );
+      if (onApprove) {
+        onApprove(selectedClinic);
       }
     } else {
       toast.error(result.error || "Failed to verify clinic");
@@ -131,8 +117,8 @@ const RegistrationQueue = ({ onApprove, onReject, onViewAll }) => {
   };
 
   const processRejection = async () => {
-    // First verify the clinic with rejection notes
-    const result = await verifyClinic(selectedClinic.id, {
+    const statusResult = await updateVerifyClinic(selectedClinic.id, {
+      status: "rejected",
       verified_by: currentUser.id,
       notes:
         rejectionReason ||
@@ -141,29 +127,17 @@ const RegistrationQueue = ({ onApprove, onReject, onViewAll }) => {
         } on ${new Date().toLocaleDateString()}`,
     });
 
-    if (result.success) {
-      // Update verification status to "rejected"
-      const statusResult = await updateVerifyClinic(selectedClinic.id, {
-        status: "rejected",
-      });
+    if (statusResult.success) {
+      toast.warning(`${selectedClinic.clinic_name} has been rejected`);
+      setPendingClinics((prev) =>
+        prev.filter((c) => c.id !== selectedClinic.id)
+      );
 
-      if (statusResult.success) {
-        toast.warning(`${selectedClinic.clinic_name} has been rejected`);
-
-        // Remove clinic from pending list
-        setPendingClinics((prev) =>
-          prev.filter((c) => c.id !== selectedClinic.id)
-        );
-
-        // Call parent callback if provided
-        if (onReject) {
-          onReject(selectedClinic);
-        }
-      } else {
-        toast.error(statusResult.error || "Failed to update rejection status");
+      if (onReject) {
+        onReject(selectedClinic);
       }
     } else {
-      toast.error(result.error || "Failed to process rejection");
+      toast.error(statusResult.error || "Failed to update rejection status");
     }
   };
 

--- a/src/views/patient/__tests__/SessionExpiry.integration.test.jsx
+++ b/src/views/patient/__tests__/SessionExpiry.integration.test.jsx
@@ -34,7 +34,7 @@ describe("Session expiry integration", () => {
 
     // Make a request that will trigger the 401 interceptor
     try {
-      await apiClient.get("/api/v1/patients/patients/me");
+      await apiClient.get("/api/v1/patients/user/u1");
     } catch {
       // Expected to fail
     }


### PR DESCRIPTION
## Summary
- Add crash-resilience/error-boundary work and React Query domain hook migration already present on this branch.
- Align patient, appointment, provider, and admin API services with backend-supported routes.
- Expand patient/provider/admin hooks and add service/hook regression tests for stale endpoint coverage.

## Test Plan
- [x] npm run test:ci
- [x] npm run build

## Notes
- Clinic rejection still needs backend support for a reject/update-verification-status route; the frontend now avoids marking rejected clinics as verified.