### PR TITLE
feat(auth): add staff invitation registration UI + API wiring

### DIFF
--- a/src/api/services/__tests__/adminService.test.js
+++ b/src/api/services/__tests__/adminService.test.js
@@ -37,4 +37,78 @@ describe("adminService", () => {
       admin_level: "super_admin",
     });
   });
+
+  it("loads a system admin by id", async () => {
+    apiClient.get.mockResolvedValue({
+      data: { id: "a1", user_id: "u1", admin_level: "super_admin" },
+    });
+
+    const result = await adminService.getSystemAdmin("a1");
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/v1/admin/system-admins/a1"
+    );
+    expect(result).toEqual({ id: "a1", user_id: "u1", admin_level: "super_admin" });
+  });
+
+  it("updates a system admin by id", async () => {
+    apiClient.put.mockResolvedValue({
+      data: { id: "a1", admin_level: "regional" },
+    });
+
+    const result = await adminService.updateSystemAdmin("a1", {
+      admin_level: "regional",
+    });
+
+    expect(apiClient.put).toHaveBeenCalledWith(
+      "/api/v1/admin/system-admins/a1",
+      { admin_level: "regional" }
+    );
+    expect(result).toEqual({ id: "a1", admin_level: "regional" });
+  });
+
+  it("deletes a system admin by id", async () => {
+    apiClient.delete.mockResolvedValue({
+      data: { message: "System admin deleted successfully" },
+    });
+
+    const result = await adminService.deleteSystemAdmin("a1");
+
+    expect(apiClient.delete).toHaveBeenCalledWith(
+      "/api/v1/admin/system-admins/a1"
+    );
+    expect(result).toEqual({ message: "System admin deleted successfully" });
+  });
+
+  it("deletes a system admin by user id", async () => {
+    apiClient.delete.mockResolvedValue({
+      data: { message: "System admin deleted successfully" },
+    });
+
+    const result = await adminService.deleteSystemAdminByUserId("u1");
+
+    expect(apiClient.delete).toHaveBeenCalledWith(
+      "/api/v1/admin/system-admins/user/u1"
+    );
+    expect(result).toEqual({ message: "System admin deleted successfully" });
+  });
+
+  it("searches system admins with filters", async () => {
+    apiClient.get.mockResolvedValue({
+      data: [{ id: "a1" }, { id: "a2" }],
+    });
+
+    const result = await adminService.searchSystemAdmins({
+      admin_level: "super_admin",
+      region: "North",
+      query: "john",
+      limit: 10,
+      offset: 2,
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith(
+      "/api/v1/admin/system-admins/search?admin_level=super_admin&region=North&query=john&limit=10&offset=2"
+    );
+    expect(result).toEqual([{ id: "a1" }, { id: "a2" }]);
+  });
 });

--- a/src/api/services/__tests__/providerService.test.js
+++ b/src/api/services/__tests__/providerService.test.js
@@ -40,4 +40,19 @@ describe("providerService", () => {
 
     expect(apiClient.put).not.toHaveBeenCalled();
   });
+
+  it("registers provider credentials with backend-compatible endpoint", async () => {
+    apiClient.post.mockResolvedValue({
+      data: { id: "cred1", credential_type: "licence" },
+    });
+
+    const payload = { credential_type: "licence", number: "ABC123" };
+    const result = await providerService.registerCredential(payload);
+
+    expect(apiClient.post).toHaveBeenCalledWith(
+      "/api/v1/providers/credentials",
+      payload
+    );
+    expect(result).toEqual({ id: "cred1", credential_type: "licence" });
+  });
 });

--- a/src/api/services/adminService.js
+++ b/src/api/services/adminService.js
@@ -9,10 +9,6 @@ const getCurrentUserId = () => {
   return userId;
 };
 
-const unsupportedAdminOperation = (operation) => {
-  throw new Error(`${operation} is not supported by the backend admin API`);
-};
-
 /**
  * Admin Service
  * Handles all API calls related to system admin operations
@@ -58,9 +54,8 @@ const adminService = {
    * @returns {Promise<Object>} System admin profile
    */
   getSystemAdmin: async (adminId) => {
-    return unsupportedAdminOperation(
-      `Loading system admin by profile ID ${adminId}`
-    );
+    const response = await apiClient.get(`/api/v1/admin/system-admins/${adminId}`);
+    return response.data;
   },
 
   /**
@@ -70,9 +65,11 @@ const adminService = {
    * @returns {Promise<Object>} Updated system admin profile
    */
   updateSystemAdmin: async (adminId, data) => {
-    return unsupportedAdminOperation(
-      `Updating system admin by profile ID ${adminId}`
+    const response = await apiClient.put(
+      `/api/v1/admin/system-admins/${adminId}`,
+      data
     );
+    return response.data;
   },
 
   /**
@@ -81,9 +78,10 @@ const adminService = {
    * @returns {Promise<Object>} Success message
    */
   deleteSystemAdmin: async (adminId) => {
-    return unsupportedAdminOperation(
-      `Deleting system admin by profile ID ${adminId}`
+    const response = await apiClient.delete(
+      `/api/v1/admin/system-admins/${adminId}`
     );
+    return response.data;
   },
 
   /**
@@ -92,9 +90,10 @@ const adminService = {
    * @returns {Promise<Object>} Success message
    */
   deleteSystemAdminByUserId: async (userId) => {
-    return unsupportedAdminOperation(
-      `Deleting system admin by user ID ${userId}`
+    const response = await apiClient.delete(
+      `/api/v1/admin/system-admins/user/${userId}`
     );
+    return response.data;
   },
 
   /**
@@ -108,8 +107,38 @@ const adminService = {
    * @param {number} params.offset - Results offset
    * @returns {Promise<Object>} Search results
    */
-  searchSystemAdmins: async () => {
-    return unsupportedAdminOperation("Searching system admins");
+  searchSystemAdmins: async (params = {}) => {
+    const queryParams = new URLSearchParams();
+
+    if (params.admin_level?.trim()) {
+      queryParams.append("admin_level", params.admin_level);
+    }
+
+    if (params.region?.trim()) {
+      queryParams.append("region", params.region);
+    }
+
+    if (params.department?.trim()) {
+      queryParams.append("department", params.department);
+    }
+
+    if (params.query?.trim()) {
+      queryParams.append("query", params.query);
+    }
+
+    if (typeof params.limit === "number" && Number.isFinite(params.limit)) {
+      queryParams.append("limit", String(params.limit));
+    }
+
+    if (typeof params.offset === "number" && Number.isFinite(params.offset)) {
+      queryParams.append("offset", String(params.offset));
+    }
+
+    const query = queryParams.toString();
+    const response = await apiClient.get(
+      `/api/v1/admin/system-admins/search${query ? `?${query}` : ""}`
+    );
+    return response.data;
   },
 
   /**

--- a/src/api/services/authService.js
+++ b/src/api/services/authService.js
@@ -10,6 +10,11 @@ const authService = {
     return response.data;
   },
 
+  registerInvitedStaff: async (data) => {
+    const response = await apiClient.post("/api/v1/auth/register/staff", data);
+    return response.data;
+  },
+
   login: async (credentials) => {
     const response = await apiClient.post("/api/v1/auth/login", credentials);
     return response.data;

--- a/src/api/services/providerService.js
+++ b/src/api/services/providerService.js
@@ -269,7 +269,7 @@ const providerService = {
   // Credential routes
   registerCredential: async (data) => {
     const response = await apiClient.post(
-      "/api/v1/providers/credentials/",
+      "/api/v1/providers/credentials",
       data
     );
     return response.data;

--- a/src/components/icons/DarkmodeIcon.jsx
+++ b/src/components/icons/DarkmodeIcon.jsx
@@ -1,6 +1,6 @@
 const DarkmodeIcon = () => {
   return (
-    <span class="cursor-pointer">
+    <span className="cursor-pointer">
       <svg
         width="18"
         height="18"

--- a/src/components/icons/NotificationIcon.jsx
+++ b/src/components/icons/NotificationIcon.jsx
@@ -1,6 +1,6 @@
 const NotificationIcon = () => {
   return (
-    <span class="cursor-pointer">
+    <span className="cursor-pointer">
       <svg
         width="12"
         height="18"

--- a/src/components/icons/SearchIcon.jsx
+++ b/src/components/icons/SearchIcon.jsx
@@ -2,15 +2,15 @@ const SearchIcon = () => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      class="mx-3 my-[12px] h-5 w-5 cursor-pointer text-navy-700"
+      className="mx-3 my-[12px] h-5 w-5 cursor-pointer text-navy-700"
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
     >
       <path
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2"
         d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
       />
     </svg>

--- a/src/components/icons/ThemsIcon.jsx
+++ b/src/components/icons/ThemsIcon.jsx
@@ -1,6 +1,6 @@
 const ThemsIcon = () => {
   return (
-    <span class="cursor-pointer">
+    <span className="cursor-pointer">
       <svg
         width="16"
         height="20"
@@ -8,7 +8,7 @@ const ThemsIcon = () => {
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <g clip-path="url(#clip0_201_2879)">
+        <g clipPath="url(#clip0_201_2879)">
           <path
             d="M11 7H13V9H11V7ZM12 17C12.55 17 13 16.55 13 16V12C13 11.45 12.55 11 12 11C11.45 11 11 11.45 11 12V16C11 16.55 11.45 17 12 17ZM12 2C6.48 2 2 6.48 2 12C2 17.52 6.48 22 12 22C17.52 22 22 17.52 22 12C22 6.48 17.52 2 12 2ZM12 20C7.59 20 4 16.41 4 12C4 7.59 7.59 4 12 4C16.41 4 20 7.59 20 12C20 16.41 16.41 20 12 20Z"
             fill="#A3AED0"

--- a/src/components/navbar/RTL.jsx
+++ b/src/components/navbar/RTL.jsx
@@ -55,7 +55,7 @@ const Navbar = (props) => {
           <input
             type="text"
             placeholder="Search..."
-            class="block h-full w-full rounded-full bg-lightPrimary text-sm font-medium text-navy-700 outline-none placeholder:!text-gray-400 dark:bg-navy-900 dark:text-white dark:placeholder:!text-white sm:w-fit"
+            className="block h-full w-full rounded-full bg-lightPrimary text-sm font-medium text-navy-700 outline-none placeholder:!text-gray-400 dark:bg-navy-900 dark:text-white dark:placeholder:!text-white sm:w-fit"
           />
         </div>
         <span

--- a/src/components/navbar/index.jsx
+++ b/src/components/navbar/index.jsx
@@ -55,7 +55,7 @@ const Navbar = (props) => {
           <input
             type="text"
             placeholder="Search..."
-            class="block h-full w-full rounded-full bg-lightPrimary text-sm font-medium text-navy-700 outline-none placeholder:!text-gray-400 dark:bg-navy-900 dark:text-white dark:placeholder:!text-white sm:w-fit"
+            className="block h-full w-full rounded-full bg-lightPrimary text-sm font-medium text-navy-700 outline-none placeholder:!text-gray-400 dark:bg-navy-900 dark:text-white dark:placeholder:!text-white sm:w-fit"
           />
         </div>
         <span

--- a/src/components/sidebar/RTL.jsx
+++ b/src/components/sidebar/RTL.jsx
@@ -20,12 +20,12 @@ const Sidebar = ({ open, onClose }) => {
         <HiX />
       </span>
 
-      <div className={`mx-[56px] mt-[50px] flex items-center`}>
-        <div className="mt-1 h-2.5 font-poppins text-[26px] font-bold uppercase text-navy-700 ms-1 dark:text-white">
-          Horizon <span class="font-medium">FREE</span>
+        <div className={`mx-[56px] mt-[50px] flex items-center`}>
+          <div className="mt-1 h-2.5 font-poppins text-[26px] font-bold uppercase text-navy-700 ms-1 dark:text-white">
+          Horizon <span className="font-medium">FREE</span>
         </div>
       </div>
-      <div class="mt-[58px] mb-7 h-px bg-gray-300 dark:bg-white/30" />
+      <div className="mt-[58px] mb-7 h-px bg-gray-300 dark:bg-white/30" />
       {/* Nav item */}
 
       <ul className="mb-auto pt-1">

--- a/src/components/sidebar/componentsrtl/Links.jsx
+++ b/src/components/sidebar/componentsrtl/Links.jsx
@@ -49,7 +49,7 @@ export function SidebarLinks(props) {
                 </p>
               </li>
               {activeRoute(route.path) ? (
-                <div class="absolute top-px h-9 w-1 rounded-lg bg-brand-500 end-0 dark:bg-brand-400" />
+                <div className="absolute top-px h-9 w-1 rounded-lg bg-brand-500 end-0 dark:bg-brand-400" />
               ) : null}
             </div>
           </Link>

--- a/src/components/sidebar/index.jsx
+++ b/src/components/sidebar/index.jsx
@@ -22,10 +22,10 @@ const Sidebar = ({ open, onClose }) => {
 
       <div className={`mx-[56px] mt-[50px] flex items-center`}>
         <div className="mt-1 ml-1 h-2.5 font-poppins text-[26px] font-bold uppercase text-navy-700 dark:text-white">
-          Horizon <span class="font-medium">FREE</span>
+          Horizon <span className="font-medium">FREE</span>
         </div>
       </div>
-      <div class="mt-[58px] mb-7 h-px bg-gray-300 dark:bg-white/30" />
+      <div className="mt-[58px] mb-7 h-px bg-gray-300 dark:bg-white/30" />
       {/* Nav item */}
 
       <ul className="mb-auto pt-1">

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -47,6 +47,39 @@ export const AuthProvider = ({ children }) => {
     };
   }, []);
 
+  const registerInvitedStaff = useCallback(async (data) => {
+    try {
+      if (!isMounted.current)
+        return { success: false, error: "Component unmounted" };
+
+      setLoading(true);
+      const response = await authService.registerInvitedStaff(data);
+
+      if (response?.token && response?.user) {
+        sessionManager.saveSession({
+          token: response.token,
+          user: response.user,
+          expiresAt: response.expires_at,
+        });
+        setUser(response.user);
+        setIsAuthenticated(true);
+      } else if (response?.user) {
+        setUser(response.user);
+      }
+
+      return { success: true, data: response };
+    } catch (error) {
+      const errorMessage =
+        error.response?.data?.error || "Staff registration failed";
+      console.error("Staff registration error:", error);
+      return { success: false, error: errorMessage };
+    } finally {
+      if (isMounted.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
   const register = useCallback(async (data) => {
     try {
       if (!isMounted.current)
@@ -360,6 +393,7 @@ export const AuthProvider = ({ children }) => {
       verifyEmail,
       requestPasswordReset,
       resetPassword,
+      registerInvitedStaff,
       generateOTP,
       verifyOTP,
       resendVerification,
@@ -385,6 +419,7 @@ export const AuthProvider = ({ children }) => {
       verifyEmail,
       requestPasswordReset,
       resetPassword,
+      registerInvitedStaff,
       generateOTP,
       verifyOTP,
       resendVerification,

--- a/src/hooks/useAdmin.js
+++ b/src/hooks/useAdmin.js
@@ -146,8 +146,16 @@ export const useAdmin = () => {
         setAdminState(response);
         return response;
       }, "Failed to load system admin"),
-    [queryClient, run, setAdminState]
+      [queryClient, run, setAdminState]
   );
+
+  const clearAdmin = useCallback(() => {
+    setAdmin(null);
+    setPermissions(emptyPermissions);
+    setError(null);
+    queryClient.removeQueries({ queryKey: queryKeys.admin.current });
+    queryClient.removeQueries({ queryKey: queryKeys.admin.permissions });
+  }, [queryClient]);
 
   const updateSystemAdmin = useCallback(
     async (adminId, data) =>
@@ -161,7 +169,7 @@ export const useAdmin = () => {
         });
         return response;
       }, "Failed to update system admin"),
-    [queryClient, run, setAdminState]
+      [queryClient, run, setAdminState]
   );
 
   const deleteSystemAdmin = useCallback(
@@ -237,14 +245,6 @@ export const useAdmin = () => {
     () => adminService.getAllAdminLevels(),
     []
   );
-
-  const clearAdmin = useCallback(() => {
-    setAdmin(null);
-    setPermissions(emptyPermissions);
-    setError(null);
-    queryClient.removeQueries({ queryKey: queryKeys.admin.current });
-    queryClient.removeQueries({ queryKey: queryKeys.admin.permissions });
-  }, [queryClient]);
 
   const clearError = useCallback(() => setError(null), []);
 

--- a/src/hooks/useAdmin.js
+++ b/src/hooks/useAdmin.js
@@ -136,12 +136,91 @@ export const useAdmin = () => {
     [admin]
   );
 
-  const unsupported = useCallback(
-    async (operation) => ({
-      success: false,
-      error: `${operation} is not supported by the backend admin API`,
-    }),
-    []
+  const getSystemAdmin = useCallback(
+    async (adminId) =>
+      run(async () => {
+        const response = await queryClient.fetchQuery({
+          queryKey: [...queryKeys.admin.profile, "id", adminId],
+          queryFn: () => adminService.getSystemAdmin(adminId),
+        });
+        setAdminState(response);
+        return response;
+      }, "Failed to load system admin"),
+    [queryClient, run, setAdminState]
+  );
+
+  const updateSystemAdmin = useCallback(
+    async (adminId, data) =>
+      run(async () => {
+        const response = await adminService.updateSystemAdmin(adminId, data);
+        setAdminState(response);
+        queryClient.invalidateQueries({ queryKey: queryKeys.admin.current });
+        queryClient.invalidateQueries({ queryKey: queryKeys.admin.users });
+        queryClient.removeQueries({
+          queryKey: [...queryKeys.admin.profile, "id", adminId],
+        });
+        return response;
+      }, "Failed to update system admin"),
+    [queryClient, run, setAdminState]
+  );
+
+  const deleteSystemAdmin = useCallback(
+    async (adminId) =>
+      run(async () => {
+        const response = await adminService.deleteSystemAdmin(adminId);
+
+        queryClient.removeQueries({
+          queryKey: queryKeys.admin.current,
+        });
+        queryClient.removeQueries({
+          queryKey: [...queryKeys.admin.profile, "id", adminId],
+        });
+        queryClient.invalidateQueries({ queryKey: queryKeys.admin.users });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.permissions,
+        });
+
+        if (admin?.id === adminId) {
+          clearAdmin();
+        }
+
+        return response;
+      }, "Failed to delete system admin"),
+    [admin, clearAdmin, queryClient, run]
+  );
+
+  const deleteSystemAdminByUserId = useCallback(
+    async (userId) =>
+      run(async () => {
+        const response = await adminService.deleteSystemAdminByUserId(userId);
+        queryClient.removeQueries({
+          queryKey: [...queryKeys.admin.profile, "user", userId],
+        });
+        queryClient.removeQueries({
+          queryKey: queryKeys.admin.current,
+        });
+        queryClient.invalidateQueries({ queryKey: queryKeys.admin.users });
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.admin.permissions,
+        });
+
+        if (admin?.user_id === userId) {
+          clearAdmin();
+        }
+
+        return response;
+      }, "Failed to delete system admin"),
+    [admin, clearAdmin, queryClient, run]
+  );
+
+  const searchSystemAdmins = useCallback(
+    async (params = {}) =>
+      run(async () => {
+        const response = await adminService.searchSystemAdmins(params);
+        queryClient.setQueryData(queryKeys.admin.search(params), response);
+        return response;
+      }, "Failed to search system admins"),
+    [queryClient, run]
   );
 
   const validateAdminData = useCallback(
@@ -171,15 +250,13 @@ export const useAdmin = () => {
 
   return {
     createSystemAdmin,
-    getSystemAdmin: (adminId) =>
-      unsupported(`Loading system admin by profile ID ${adminId}`),
+    getSystemAdmin,
     getSystemAdminByUserId,
     getCurrentSystemAdminProfile,
-    updateSystemAdmin: (adminId) =>
-      unsupported(`Updating system admin by profile ID ${adminId}`),
-    deleteSystemAdmin: (adminId) =>
-      unsupported(`Deleting system admin by profile ID ${adminId}`),
-    searchSystemAdmins: () => unsupported("Searching system admins"),
+    updateSystemAdmin,
+    deleteSystemAdmin,
+    deleteSystemAdminByUserId,
+    searchSystemAdmins,
     upsertSystemAdminProfile: createSystemAdmin,
     getPermissions,
     hasPermission,

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -1,6 +1,7 @@
 import authService from "api/services/authService";
 import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { sessionManager } from "platform/auth/sessionManager";
 
 /**
  * Custom hook for authentication operations
@@ -22,6 +23,24 @@ export const useAuth = () => {
       return { success: true, data: response };
     } catch (err) {
       const errorMessage = err.response?.data?.error || "Registration failed";
+      setError(errorMessage);
+      setLoading(false);
+      return { success: false, error: errorMessage };
+    }
+  }, []);
+
+  // register staff via invitation token
+  const registerInvitedStaff = useCallback(async (data) => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await authService.registerInvitedStaff(data);
+      setLoading(false);
+      return { success: true, data: response };
+    } catch (err) {
+      const errorMessage =
+        err.response?.data?.error || "Staff registration failed";
       setError(errorMessage);
       setLoading(false);
       return { success: false, error: errorMessage };
@@ -51,7 +70,7 @@ export const useAuth = () => {
     setError(null);
     try {
       await authService.logout();
-      navigate("/signin");
+      navigate("/auth/sign-in");
       setLoading(false);
       return { success: true };
     } catch (err) {
@@ -141,8 +160,7 @@ export const useAuth = () => {
       setLoading(false);
       return { success: true, data: response };
     } catch (err) {
-      const errorMessage =
-        err.response?.data?.error || "Failed to generate OTP";
+      const errorMessage = err.response?.data?.error || "Failed to generate OTP";
       setError(errorMessage);
       setLoading(false);
       return { success: false, error: errorMessage };
@@ -221,6 +239,19 @@ export const useAuth = () => {
     }
   }, []);
 
+  const getCurrentUser = useCallback(() => {
+    return sessionManager.hydrate().user;
+  }, []);
+
+  const getToken = useCallback(() => {
+    return sessionManager.hydrate().token;
+  }, []);
+
+  const isAuthenticated = () => {
+    const { token, expiresAt } = sessionManager.hydrate();
+    return Boolean(token && expiresAt && new Date(expiresAt) > new Date());
+  };
+
   /**
    * Clear error
    */
@@ -231,6 +262,7 @@ export const useAuth = () => {
   return {
     // Methods
     register,
+    registerInvitedStaff,
     login,
     logout,
     verifyEmail,
@@ -249,8 +281,8 @@ export const useAuth = () => {
     error,
 
     // Utility methods
-    isAuthenticated: authService.isAuthenticated,
-    getCurrentUser: authService.getCurrentUser,
-    getToken: authService.getToken,
+    isAuthenticated: isAuthenticated(),
+    getCurrentUser,
+    getToken,
   };
 };

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,12 @@ import "./index.css";
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <GlobalErrorBoundary>
-    <BrowserRouter>
+    <BrowserRouter
+      future={{
+        v7_startTransition: true,
+        v7_relativeSplatPath: true,
+      }}
+    >
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>

--- a/src/platform/query/queryKeys.js
+++ b/src/platform/query/queryKeys.js
@@ -17,6 +17,7 @@ export const queryKeys = {
     profile: ["admin", "profile"],
     permissions: ["admin", "permissions"],
     users: ["admin", "users"],
+    search: (params) => ["admin", "search", params],
   },
   staff: {
     list: ["staff", "list"],

--- a/src/routes.js
+++ b/src/routes.js
@@ -46,6 +46,7 @@ import ResetPassword from "views/auth/ResetPassword";
 import VerifyEmail from "views/auth/VerifyEmail";
 import ChangePassword from "views/auth/ChangePassword";
 import ConsentSettings from "views/auth/ConsentSettings";
+import StaffRegistration from "views/auth/StaffRegistration";
 
 // Landing Page View
 import LandingPage from "views/landing";
@@ -406,5 +407,13 @@ export const authRoutes = [
     path: "verify-email",
     icon: <MdLock className="h-6 w-6" />,
     component: <VerifyEmail />,
+  },
+  {
+    name: "Staff Registration",
+    layout: "/auth",
+    path: "register/staff",
+    icon: <MdLock className="h-6 w-6" />,
+    component: <StaffRegistration />,
+    sidebar: false,
   },
 ];

--- a/src/views/auth/ForgotPassword.jsx
+++ b/src/views/auth/ForgotPassword.jsx
@@ -84,7 +84,9 @@ const ForgotPassword = () => {
       if (result.success) {
         setTimer(60);
         setStep(2);
-        showToast(`OTP sent to ${formData.identifier}`, "success");
+        const sentVia =
+          result?.data?.channel === "email" ? "Email" : "SMS";
+        showToast(`OTP sent via ${sentVia}`, "success");
       } else {
         showToast(result.error || "Failed to send OTP", "error");
       }
@@ -123,7 +125,9 @@ const ForgotPassword = () => {
 
       if (result.success) {
         setTimer(60);
-        showToast("OTP resent successfully", "success");
+        const sentVia =
+          result?.data?.channel === "email" ? "Email" : "SMS";
+        showToast(`OTP resent via ${sentVia}`, "success");
       } else {
         showToast(result.error || "Failed to resend OTP", "error");
       }

--- a/src/views/auth/StaffRegistration.jsx
+++ b/src/views/auth/StaffRegistration.jsx
@@ -1,0 +1,453 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import InputField from "components/fields/InputField";
+import { FaEye, FaEyeSlash } from "react-icons/fa";
+import { MdArrowBack, MdLock, MdWork } from "react-icons/md";
+import { useToast } from "hooks/useToast";
+import { useAuth } from "context/AuthContext";
+import staffService from "api/services/staffService";
+import { getDashboardPath } from "utils/roleUtils";
+
+const StaffRegistration = () => {
+  const [searchParams] = useSearchParams();
+  const invitationToken = searchParams.get("invitation_token");
+  const navigate = useNavigate();
+  const { showToast } = useToast();
+  const { registerInvitedStaff } = useAuth();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetchingInvitation, setIsFetchingInvitation] = useState(true);
+  const [invitation, setInvitation] = useState(null);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [isRegistered, setIsRegistered] = useState(false);
+  const [showSuccessMessage, setShowSuccessMessage] = useState("");
+
+  const [formData, setFormData] = useState({
+    email: "",
+    phone: "",
+    password: "",
+    confirmPassword: "",
+  });
+
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    const token = invitationToken;
+    if (!token) {
+      setIsFetchingInvitation(false);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const fetchInvitation = async () => {
+      setIsFetchingInvitation(true);
+
+      try {
+        const details = await staffService.getInvitationDetails(token);
+        if (cancelled || !mountedRef.current) return;
+
+        setInvitation(details);
+        setFormData((prev) => ({
+          ...prev,
+          email: details.work_email || prev.email,
+        }));
+      } catch (error) {
+        if (!mountedRef.current || cancelled) return;
+
+        setInvitation(null);
+        showToast(
+          error.response?.data?.error || "Invalid or expired invitation",
+          "error"
+        );
+      } finally {
+        if (!cancelled && mountedRef.current) {
+          setIsFetchingInvitation(false);
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchInvitation();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [invitationToken, showToast]);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const isPhoneValid = (value) => {
+    if (!value) return true;
+    return /^(?:(?:\+27|0)[\s-]?[1-9][\d\s-]{8,9})$/.test(
+      value.replace(/\s/g, "")
+    );
+  };
+
+  const validateForm = () => {
+    if (!formData.email || !/\S+@\S+\.\S+/.test(formData.email)) {
+      showToast("Please enter a valid email address", "warning");
+      return false;
+    }
+
+    if (!formData.password.trim()) {
+      showToast("Please enter a password", "warning");
+      return false;
+    }
+
+    if (formData.password.length < 8) {
+      showToast("Password must be at least 8 characters", "warning");
+      return false;
+    }
+
+    if (!/(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(formData.password)) {
+      showToast(
+        "Password must contain uppercase, lowercase and numbers",
+        "warning"
+      );
+      return false;
+    }
+
+    if (formData.password !== formData.confirmPassword) {
+      showToast("Passwords do not match", "warning");
+      return false;
+    }
+
+    if (!isPhoneValid(formData.phone)) {
+      showToast("Please enter a valid South African phone number", "warning");
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleInputChange = (event) => {
+    const { name, value } = event.target;
+    setFormData((previous) => ({
+      ...previous,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    if (!invitationToken) {
+      showToast("Missing invitation token", "error");
+      return;
+    }
+
+    if (!validateForm()) return;
+
+    setIsLoading(true);
+
+    try {
+      const payload = {
+        invitation_token: invitationToken,
+        email: formData.email,
+        password: formData.password,
+      };
+
+      if (formData.phone.trim()) {
+        payload.phone = formData.phone;
+      }
+
+      const response = await registerInvitedStaff(payload);
+
+      if (!mountedRef.current) return;
+
+      if (!response.success) {
+        showToast(response.error || "Registration failed", "error");
+        return;
+      }
+
+      setIsRegistered(true);
+
+      if (response.data?.token) {
+        const nextPath = getDashboardPath(response.data?.user?.role || "provider_staff");
+        setShowSuccessMessage(
+          "Account created successfully. You are now signed in."
+        );
+        showToast("Registration successful", "success");
+        setTimeout(() => {
+          if (mountedRef.current) navigate(nextPath);
+        }, 1500);
+      } else {
+        setShowSuccessMessage(
+          "Registration successful. Please sign in to continue."
+        );
+      }
+    } catch (error) {
+      if (!mountedRef.current) return;
+      showToast("An unexpected error occurred", "error");
+      console.error("Staff registration submit error:", error);
+    } finally {
+      if (mountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  };
+
+  const isExpired =
+    invitation?.invitation_expires &&
+    new Date(invitation.invitation_expires) < new Date();
+
+  if (!isFetchingInvitation && !invitation) {
+    return (
+      <div className="mb-16 mt-16 flex min-h-screen w-full items-center justify-center px-2 md:px-0">
+        <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-navy-800">
+          <div className="mb-6 flex items-center">
+            <button
+              type="button"
+              onClick={() => navigate("/auth/sign-in")}
+              className="mr-3 rounded-lg p-2 text-navy-500 hover:bg-gray-100 dark:hover:bg-navy-700"
+            >
+              <MdArrowBack className="h-5 w-5" />
+            </button>
+            <h1 className="text-2xl font-bold text-navy-700 dark:text-white">
+              Invalid invitation
+            </h1>
+          </div>
+          <p className="mb-4 text-gray-600 dark:text-gray-300">
+            We couldn't find a valid staff invitation. Please check your link or
+            contact your clinic administrator.
+          </p>
+          <Link
+            to="/auth/sign-in"
+            className="inline-block rounded-xl bg-brand-500 px-6 py-3 text-sm font-semibold text-white hover:bg-brand-600"
+          >
+            Go to Sign In
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (isRegistered) {
+    return (
+      <div className="mb-16 mt-16 flex min-h-screen w-full items-center justify-center px-2 md:px-0">
+        <div className="w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-xl dark:bg-navy-800">
+          <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/20">
+            <svg
+              className="h-10 w-10 text-green-600 dark:text-green-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+
+          <h1 className="mb-2 text-2xl font-bold text-navy-700 dark:text-white">
+            Staff Registration Complete
+          </h1>
+
+          <p className="mb-6 text-gray-600 dark:text-gray-300">
+            {showSuccessMessage}
+          </p>
+
+          <button
+            onClick={() => navigate(showSuccessMessage.includes("signed in") ? "/provider/dashboard" : "/auth/sign-in")}
+            className="w-full rounded-xl bg-brand-500 py-3 text-white hover:bg-brand-600"
+          >
+            {showSuccessMessage.includes("signed in") ? "Go to dashboard" : "Go to sign in"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-16 mt-16 flex min-h-screen items-center justify-center px-2 md:mx-0 md:px-0 lg:mb-10">
+      <div className="w-full max-w-2xl rounded-2xl bg-white p-6 shadow-xl dark:bg-navy-800 md:p-10">
+        <div className="mb-8 flex items-center">
+          <button
+            type="button"
+            onClick={() => navigate("/auth/sign-in")}
+            className="mr-3 rounded-lg p-2 text-navy-500 hover:bg-gray-100 dark:hover:bg-navy-700"
+            disabled={isFetchingInvitation}
+          >
+            <MdArrowBack className="h-5 w-5" />
+          </button>
+          <div>
+            <h1 className="text-3xl font-bold text-navy-700 dark:text-white">
+              Staff Invitation Registration
+            </h1>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              Complete your account setup to join your clinic team
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-6 rounded-xl bg-blue-50 p-4 dark:bg-blue-900/20">
+          <div className="mb-3 flex items-center gap-2 font-semibold text-blue-900 dark:text-blue-100">
+            <MdWork className="h-5 w-5" />
+            <span>Invitation Details</span>
+          </div>
+
+          {isFetchingInvitation ? (
+            <p className="text-sm text-gray-700 dark:text-gray-200">
+              Loading invitation details...
+            </p>
+          ) : isExpired ? (
+            <p className="text-sm text-red-600 dark:text-red-300">
+              This invitation link has expired. Ask your administrator for a new
+              invitation.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm text-gray-700 dark:text-gray-200">
+                <strong>Clinic:</strong> {invitation?.clinic_name}
+              </p>
+              <p className="text-sm text-gray-700 dark:text-gray-200">
+                <strong>Role:</strong> {invitation?.staff_role}
+              </p>
+              <p className="text-sm text-gray-700 dark:text-gray-200">
+                <strong>Email:</strong> {invitation?.work_email}
+              </p>
+              <p className="text-sm text-gray-700 dark:text-gray-200">
+                <strong>Invitation expires:</strong>{" "}
+                {invitation?.invitation_expires
+                  ? new Date(invitation.invitation_expires).toLocaleString()
+                  : "N/A"}
+              </p>
+            </>
+          )}
+        </div>
+
+        {isExpired && (
+          <div className="mb-6 rounded-xl bg-red-50 p-4 dark:bg-red-900/20">
+            <p className="text-sm text-red-700 dark:text-red-200">
+              This invitation is no longer valid. Please request a new invite from
+              your clinic administrator.
+            </p>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <InputField
+            variant="auth"
+            label="Email Address *"
+            placeholder="your.email@example.com"
+            id="email"
+            name="email"
+            value={formData.email}
+            onChange={handleInputChange}
+            type="email"
+            disabled
+          />
+
+          <InputField
+            variant="auth"
+            label="Phone number (optional)"
+            placeholder="+27 82 123 4567"
+            id="phone"
+            name="phone"
+            value={formData.phone}
+            onChange={handleInputChange}
+            type="tel"
+            disabled={isLoading || isFetchingInvitation}
+          />
+
+          <div className="relative">
+            <InputField
+              variant="auth"
+              label="Password *"
+              placeholder="Min. 8 characters"
+              id="password"
+              name="password"
+              value={formData.password}
+              onChange={handleInputChange}
+              type={showPassword ? "text" : "password"}
+              disabled={isLoading || isFetchingInvitation}
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((prev) => !prev)}
+              className="absolute right-3 top-10 text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={isLoading || isFetchingInvitation}
+            >
+              {showPassword ? <FaEyeSlash /> : <FaEye />}
+            </button>
+          </div>
+
+          <div className="relative">
+            <InputField
+              variant="auth"
+              label="Confirm Password *"
+              placeholder="Re-enter your password"
+              id="confirmPassword"
+              name="confirmPassword"
+              value={formData.confirmPassword}
+              onChange={handleInputChange}
+              type={showConfirmPassword ? "text" : "password"}
+              disabled={isLoading || isFetchingInvitation}
+            />
+            <button
+              type="button"
+              onClick={() => setShowConfirmPassword((prev) => !prev)}
+              className="absolute right-3 top-10 text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={isLoading || isFetchingInvitation}
+            >
+              {showConfirmPassword ? <FaEyeSlash /> : <FaEye />}
+            </button>
+          </div>
+
+          <button
+            type="submit"
+            disabled={
+              isLoading ||
+              isFetchingInvitation ||
+              !invitationToken ||
+              isExpired ||
+              !invitation
+            }
+            className="linear mt-2 w-full rounded-xl bg-brand-500 py-[12px] text-base font-medium text-white transition duration-200 hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-brand-400 dark:hover:bg-brand-300 dark:active:bg-brand-200"
+          >
+            {isLoading ? (
+              <span className="flex items-center justify-center">
+                <svg
+                  className="mr-2 h-5 w-5 animate-spin"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                    fill="none"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                Creating account...
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-2">
+                <MdLock className="h-5 w-5" />
+                Complete Registration
+              </span>
+            )}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default StaffRegistration;


### PR DESCRIPTION
## Summary
- Adds staff invitation registration UI and API integration flow
  - Adds registration page route: `/auth/register/staff?invitation_token=...`.
  - Adds auth API call for `POST /api/v1/auth/register/staff`.
  - Integrates invitation detail fetch and submit flow with robust loading/expiry/error states.
  - Reuses invitation services for:
    - `GET /api/v1/staff/invitations/{token}`
    - `POST /api/v1/staff/invitations/{token}/accept`
    - `POST /api/v1/staff/invitations/{token}/decline`
    - `GET /api/v1/staff/invitations/my`
    - `POST /api/v1/providers/clinics/{clinic_id}/staff/invitations/{invitation_id}/resend`
    - `DELETE /api/v1/providers/clinics/{clinic_id}/staff/invitations/{token}`

- State handling
  - Adds `registerInvitedStaff` in `useAuth`/`AuthContext` with session handoff when token is returned.

- Validation
  - Existing automated checks pass:
    - `npm run test:ci`
    - `npm run build`

