### PR TITLE
fix: resolve 6 critical bugs blocking all user dashboards

### DIFF
--- a/src/hooks/useAppointment.js
+++ b/src/hooks/useAppointment.js
@@ -217,7 +217,7 @@ export const useAppointment = () => {
     }
   };
 
-  const getAppointmentsByPatient = async (patientId) => {
+  const getAppointmentsByPatient = useCallback(async (patientId) => {
     startLoading();
     setError(null);
     try {
@@ -238,7 +238,7 @@ export const useAppointment = () => {
       stopLoading();
       return { success: false, error: errorMessage };
     }
-  };
+  }, [queryClient, startLoading, stopLoading]);
 
   const getAppointmentsByClinic = async (clinicId) => {
     startLoading();
@@ -286,7 +286,7 @@ export const useAppointment = () => {
     }
   };
 
-  const getTodayAppointments = async (clinicId) => {
+  const getTodayAppointments = useCallback(async (clinicId) => {
     startLoading();
     setError(null);
     try {
@@ -307,9 +307,9 @@ export const useAppointment = () => {
       stopLoading();
       return { success: false, error: errorMessage };
     }
-  };
+  }, [queryClient, startLoading, stopLoading]);
 
-  const getPendingAppointments = async (clinicId) => {
+  const getPendingAppointments = useCallback(async (clinicId) => {
     startLoading();
     setError(null);
     try {
@@ -330,7 +330,7 @@ export const useAppointment = () => {
       stopLoading();
       return { success: false, error: errorMessage };
     }
-  };
+  }, [queryClient, startLoading, stopLoading]);
 
   const rescheduleAppointment = async (id, data) => {
     startLoading();

--- a/src/hooks/useStaff.js
+++ b/src/hooks/useStaff.js
@@ -19,25 +19,29 @@ export const useStaff = () => {
   const [activeInvitationKey, setActiveInvitationKey] = useState(null);
   const [activeInvitationsKey, setActiveInvitationsKey] = useState(null);
 
-  // Query observers
+  // Query observers (read from cache, never fetch directly)
   const staffQuery = useQuery({
     queryKey: activeStaffKey || ["staff", "detail"],
     enabled: false,
+    queryFn: () => Promise.resolve(null),
   });
 
   const staffListQuery = useQuery({
     queryKey: activeStaffListKey || queryKeys.staff.list,
     enabled: false,
+    queryFn: () => Promise.resolve(null),
   });
 
   const invitationQuery = useQuery({
     queryKey: activeInvitationKey || ["staff", "invitation"],
     enabled: false,
+    queryFn: () => Promise.resolve(null),
   });
 
   const invitationsQuery = useQuery({
     queryKey: activeInvitationsKey || ["staff", "invitations"],
     enabled: false,
+    queryFn: () => Promise.resolve(null),
   });
 
   // Derived state from queries

--- a/src/hooks/useSymptomChecker.js
+++ b/src/hooks/useSymptomChecker.js
@@ -21,20 +21,23 @@ export const useSymptomChecker = () => {
   const [activeSessionsKey, setActiveSessionsKey] = useState(null);
   const [activeEligibleKey, setActiveEligibleKey] = useState(null);
 
-  // Query observers
+  // Query observers (read from cache, never fetch directly)
   const sessionQuery = useQuery({
     queryKey: activeSessionKey || queryKeys.symptom.data,
     enabled: false,
+    queryFn: () => Promise.resolve(null),
   });
 
   const sessionsQuery = useQuery({
     queryKey: activeSessionsKey || queryKeys.symptom.history,
     enabled: false,
+    queryFn: () => Promise.resolve(null),
   });
 
   const eligibleQuery = useQuery({
     queryKey: activeEligibleKey || ["symptoms", "eligible"],
     enabled: false,
+    queryFn: () => Promise.resolve(null),
   });
 
   // Derived state from queries

--- a/src/hooks/useToast.js
+++ b/src/hooks/useToast.js
@@ -1,12 +1,14 @@
-import { createContext, useState, useCallback, useContext } from "react";
+import { createContext, useState, useCallback, useContext, useRef } from "react";
 
 const ToastContext = createContext();
 
 export const ToastProvider = ({ children }) => {
   const [toasts, setToasts] = useState([]);
+  const idCounter = useRef(0);
 
   const showToast = useCallback((message, type = "info") => {
-    const id = Date.now();
+    idCounter.current += 1;
+    const id = `${Date.now()}-${idCounter.current}`;
     setToasts((prev) => [...prev, { id, message, type }]);
     return id;
   }, []);

--- a/src/views/admin/dashboard/index.jsx
+++ b/src/views/admin/dashboard/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   MdPeople,
 } from "react-icons/md";
@@ -11,6 +11,7 @@ import SystemHealth from "../components/SystemHealth";
 import RegistrationQueue from "../components/RegistrationQueue";
 import AnalyticsChart from "../components/AnalyticsChart";
 import { useToast } from "hooks/useToast";
+import apiClient from "api/apiClient";
 
 // Component imports
 import StatsWidgets from "./components/StatsWidgets";
@@ -50,59 +51,96 @@ const SystemDashboard = () => {
   const [notificationAudience, setNotificationAudience] = useState("All Users");
   const [rejectReason, setRejectReason] = useState("");
 
-  // System alerts data
-  const systemAlerts = [
-    {
-      id: 1,
-      system: "Database Server",
-      status: "warning",
-      message: "High CPU usage detected",
-      timestamp: "2 hours ago",
-      severity: "medium",
-    },
-    {
-      id: 2,
-      system: "SMS Gateway",
-      status: "error",
-      message: "Credit balance low",
-      timestamp: "1 hour ago",
-      severity: "high",
-    },
-    {
-      id: 3,
-      system: "API Service",
-      status: "success",
-      message: "All systems operational",
-      timestamp: "5 minutes ago",
-      severity: "low",
-    },
-  ];
+  // Live stats state
+  const [liveStats, setLiveStats] = useState({
+    totalClinics: 0,
+    activeUsers: 0,
+    systemStatus: "loading",
+    systemHealthy: true,
+    statsLoading: true,
+  });
 
-  // Stats widget data
+  const [systemAlerts, setSystemAlerts] = useState([]);
+
+  // Fetch live stats from backend
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const [clinicsRes, usersRes, healthRes] = await Promise.all([
+          apiClient.get("/api/v1/providers/clinics?limit=1"),
+          apiClient.get("/api/v1/users/count"),
+          fetch("http://localhost:8080/health").then(r => r.json()),
+        ]);
+
+        const clinicCount = clinicsRes.data?.count || 0;
+        const userCount = usersRes.data?.count || 0;
+        const healthStatus = healthRes?.status === "healthy";
+        const services = healthRes?.services || {};
+
+        const healthyServices = Object.values(services).filter(s => s === "healthy").length;
+        const totalServices = Object.values(services).length;
+        const healthPercent = totalServices > 0 ? Math.round((healthyServices / totalServices) * 100) : 0;
+
+        setLiveStats({
+          totalClinics: clinicCount,
+          activeUsers: userCount,
+          systemStatus: healthStatus ? "healthy" : "degraded",
+          systemHealthy: healthStatus,
+          healthyServices,
+          totalServices,
+          healthPercent,
+          statsLoading: false,
+        });
+
+        // Build alerts from health data
+        const alerts = [];
+        Object.entries(services).forEach(([name, status]) => {
+          if (status !== "healthy" && status !== "disabled") {
+            alerts.push({
+              id: name,
+              system: name.charAt(0).toUpperCase() + name.slice(1),
+              status: status === "healthy" ? "success" : "error",
+              message: `Service status: ${status}`,
+              timestamp: "Now",
+              severity: "high",
+            });
+          }
+        });
+        setSystemAlerts(alerts);
+      } catch (err) {
+        console.error("Failed to fetch dashboard stats:", err);
+        setLiveStats(prev => ({ ...prev, statsLoading: false, systemStatus: "unknown" }));
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  // Stats widget data from live API
   const statsData = {
     totalClinics: {
       icon: <FaClinicMedical className="h-7 w-7" />,
       title: "Total Clinics",
-      value: "1,247",
-      trend: "+12% from last month",
+      value: liveStats.statsLoading ? "..." : String(liveStats.totalClinics),
+      trend: "Registered clinics",
     },
     activeUsers: {
       icon: <MdPeople className="h-7 w-7" />,
       title: "Active Users",
-      value: "45,823",
-      trend: "+8.2% this week",
+      value: liveStats.statsLoading ? "..." : String(liveStats.activeUsers),
+      trend: "Total users",
     },
     systemHealth: {
       icon: <FaServer className="h-7 w-7" />,
       title: "System Health",
-      value: "98.5%",
-      trend: "All services operational",
+      value: liveStats.statsLoading ? "..." : `${liveStats.healthPercent}%`,
+      trend: liveStats.statsLoading ? "Loading..." : `${liveStats.healthyServices}/${liveStats.totalServices} services healthy`,
     },
     smsBalance: {
       icon: <FaDatabase className="h-7 w-7" />,
-      title: "SMS Balance",
-      value: "12,458",
-      trend: "Credits remaining",
+      title: "System Status",
+      value: liveStats.systemStatus === "healthy" ? "Healthy" : liveStats.systemStatus === "loading" ? "..." : "Degraded",
+      trend: liveStats.systemStatus === "healthy" ? "All systems operational" : "Check alerts",
     },
   };
 

--- a/src/views/patient/medication-reminders/index.jsx
+++ b/src/views/patient/medication-reminders/index.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useToast } from "hooks/useToast";
 import StatsCards from "./components/StatsCards";
 import Controls from "./components/Controls";
@@ -11,6 +12,7 @@ import SettingsModal from "./components/SettingsModal";
 import DetailsModal from "./components/DetailsModal";
 
 const MedicationReminders = () => {
+  const navigate = useNavigate();
   const [reminders, setReminders] = useState([
     {
       id: 1,
@@ -148,7 +150,7 @@ const MedicationReminders = () => {
   };
 
   const handleViewAll = () => {
-    window.location.href = "/patient/medication-reminders";
+    navigate("/patient/medication-reminders");
   };
 
   const getMethodIcon = (method) => {

--- a/src/views/patient/telemedicine-chat/components/SidebarComponents.jsx
+++ b/src/views/patient/telemedicine-chat/components/SidebarComponents.jsx
@@ -1,9 +1,11 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import Card from "components/card";
 import { FaStethoscope } from "react-icons/fa";
 import { MdSchedule, MdPhone } from "react-icons/md";
 
 export const QuickActionsCard = () => {
+  const navigate = useNavigate();
   return (
     <Card extra="p-6">
       <h4 className="mb-4 text-lg font-bold text-navy-700 dark:text-white">
@@ -11,7 +13,7 @@ export const QuickActionsCard = () => {
       </h4>
       <div className="space-y-3">
         <button
-          onClick={() => (window.location.href = "/patient/symptom-checker")}
+          onClick={() => navigate("/patient/symptom-checker")}
           className="flex w-full items-center justify-between rounded-lg border border-gray-200 p-3 hover:bg-gray-50 dark:border-gray-700"
         >
           <div className="flex items-center">
@@ -21,7 +23,7 @@ export const QuickActionsCard = () => {
           <span>→</span>
         </button>
         <button
-          onClick={() => (window.location.href = "/patient/find-clinic")}
+          onClick={() => navigate("/patient/find-clinic")}
           className="flex w-full items-center justify-between rounded-lg border border-gray-200 p-3 hover:bg-gray-50 dark:border-gray-700"
         >
           <div className="flex items-center">

--- a/src/views/provider/components/TodaySchedule.jsx
+++ b/src/views/provider/components/TodaySchedule.jsx
@@ -19,7 +19,6 @@ const TodaySchedule = ({
 
   // Map database appointments to schedule format
   const schedule = React.useMemo(() => {
-    console.log("TodaySchedule - appointments prop:", appointments);
     return (appointments || []).map((apt) => ({
       id: apt.id,
       time: formatTime(apt.appointment_time),
@@ -110,8 +109,6 @@ const TodaySchedule = ({
         return "bg-gray-100 text-gray-800";
     }
   };
-
-  console.log("TodaySchedule - schedule:", schedule);
 
   return (
     <div className="rounded-[20px] bg-white p-6 dark:bg-navy-800">

--- a/src/views/provider/dashboard/components/ClinicAdminDashboard.jsx
+++ b/src/views/provider/dashboard/components/ClinicAdminDashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { IoMdPeople, IoMdTime } from "react-icons/io";
 import {
   MdCalendarToday,
@@ -22,6 +23,7 @@ import { useToast } from "hooks/useToast";
  * Displays overview of clinic operations, staff, and finances
  */
 const ClinicAdminDashboard = ({ clinicId }) => {
+  const navigate = useNavigate();
   const { showToast } = useToast();
   const { getClinic, clinic, loading: clinicLoading } = useProvider();
   const {
@@ -228,7 +230,7 @@ const ClinicAdminDashboard = ({ clinicId }) => {
             </div>
             <button
               onClick={() =>
-                (window.location.href = "/provider/appointments?status=pending")
+                navigate("/provider/appointments?status=pending")
               }
               className="ml-auto rounded-lg bg-yellow-500 px-4 py-2 text-sm font-medium text-white hover:bg-yellow-600"
             >

--- a/src/views/provider/dashboard/components/DoctorDashboard.jsx
+++ b/src/views/provider/dashboard/components/DoctorDashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { IoMdPeople, IoMdTime } from "react-icons/io";
 import { MdCalendarToday, MdCheckCircle } from "react-icons/md";
 import { FaUserMd } from "react-icons/fa";
@@ -16,6 +17,7 @@ import { useToast } from "hooks/useToast";
  * Displays appointments, patient queue, and consultation history
  */
 const DoctorDashboard = ({ clinicId }) => {
+  const navigate = useNavigate();
   const { showToast } = useToast();
   const { getCurrentUser } = useAuth();
   const {
@@ -205,7 +207,7 @@ const DoctorDashboard = ({ clinicId }) => {
               </p>
             </div>
             <button
-              onClick={() => (window.location.href = "/provider/queue")}
+              onClick={() => navigate("/provider/queue")}
               className="ml-auto rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600"
             >
               View Queue

--- a/src/views/provider/dashboard/components/ManagerDashboard.jsx
+++ b/src/views/provider/dashboard/components/ManagerDashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { IoMdPeople, IoMdTime } from "react-icons/io";
 import { MdCalendarToday, MdTrendingUp, MdAssignment } from "react-icons/md";
 import { FaBriefcase } from "react-icons/fa";
@@ -18,6 +19,7 @@ import { useToast } from "hooks/useToast";
  * Displays operational metrics, staff management, and scheduling
  */
 const ManagerDashboard = ({ clinicId }) => {
+  const navigate = useNavigate();
   const { showToast } = useToast();
   const { getCurrentUser } = useAuth();
   const { getClinic, clinic } = useProvider();
@@ -220,7 +222,7 @@ const ManagerDashboard = ({ clinicId }) => {
             </div>
             <button
               onClick={() =>
-                (window.location.href = "/provider/appointments?status=pending")
+                navigate("/provider/appointments?status=pending")
               }
               className="ml-auto rounded-lg bg-yellow-500 px-4 py-2 text-sm font-medium text-white hover:bg-yellow-600"
             >

--- a/src/views/provider/dashboard/components/NurseDashboard.jsx
+++ b/src/views/provider/dashboard/components/NurseDashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { IoMdPeople } from "react-icons/io";
 import { MdCalendarToday, MdLocalHospital } from "react-icons/md";
 import { FaUserNurse, FaSyringe, FaStethoscope } from "react-icons/fa";
@@ -14,6 +15,7 @@ import { useToast } from "hooks/useToast";
  * Displays patient queue, vitals monitoring, and nursing tasks
  */
 const NurseDashboard = ({ clinicId }) => {
+  const navigate = useNavigate();
   const { showToast } = useToast();
   const { getCurrentUser } = useAuth();
   const {
@@ -187,7 +189,7 @@ const NurseDashboard = ({ clinicId }) => {
               </p>
             </div>
             <button
-              onClick={() => (window.location.href = "/provider/queue")}
+              onClick={() => navigate("/provider/queue")}
               className="ml-auto rounded-lg bg-purple-500 px-4 py-2 text-sm font-medium text-white hover:bg-purple-600"
             >
               Record Vitals
@@ -262,7 +264,7 @@ const NurseDashboard = ({ clinicId }) => {
                       )}
                       <button
                         onClick={() =>
-                          (window.location.href = `/provider/appointments/${appointment.id}`)
+                          navigate(`/provider/appointments/${appointment.id}`)
                         }
                         className="rounded-lg bg-brand-500 px-3 py-1 text-sm text-white hover:bg-brand-600"
                       >

--- a/src/views/provider/dashboard/components/ReceptionistDashboard.jsx
+++ b/src/views/provider/dashboard/components/ReceptionistDashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { IoMdPeople, IoMdCall } from "react-icons/io";
 import { MdCalendarToday, MdCheckCircle, MdAccessTime } from "react-icons/md";
 import { FaUserCheck } from "react-icons/fa";
@@ -15,6 +16,7 @@ import { useToast } from "hooks/useToast";
  * Displays patient check-ins, appointments, and scheduling
  */
 const ReceptionistDashboard = ({ clinicId }) => {
+  const navigate = useNavigate();
   const { showToast } = useToast();
   const { getCurrentUser } = useAuth();
   const {
@@ -186,7 +188,7 @@ const ReceptionistDashboard = ({ clinicId }) => {
             </div>
             <button
               onClick={() =>
-                (window.location.href = "/provider/appointments?status=pending")
+                navigate("/provider/appointments?status=pending")
               }
               className="ml-auto rounded-lg bg-blue-500 px-4 py-2 text-sm font-medium text-white hover:bg-blue-600"
             >
@@ -293,7 +295,7 @@ const ReceptionistDashboard = ({ clinicId }) => {
                     {appointment.status !== "checked_in" && (
                       <button
                         onClick={() =>
-                          (window.location.href = `/provider/appointments/${appointment.id}/checkin`)
+                          navigate(`/provider/appointments/${appointment.id}/checkin`)
                         }
                         className="rounded-lg bg-brand-500 px-3 py-1 text-sm text-white hover:bg-brand-600"
                       >

--- a/src/views/provider/dashboard/index.jsx
+++ b/src/views/provider/dashboard/index.jsx
@@ -11,7 +11,7 @@ import ManagerDashboard from "./components/ManagerDashboard";
  */
 const ProviderDashboard = () => {
   const { user } = useAuth();
-  const { getClinics, loading: clinicsLoading } = useProvider();
+  const { getMyClinic, loading: providerLoading } = useProvider();
 
   const [loading, setLoading] = useState(true);
   const [userRole, setUserRole] = useState(null);
@@ -29,22 +29,17 @@ const ProviderDashboard = () => {
           return;
         }
 
-        // Get user's clinics to determine role
-        const { success, data, error: clinicsError } = await getClinics();
+        setUserRole(user.role);
 
-        if (!success || !data?.clinics || data.clinics.length === 0) {
-          setError(clinicsError || "No clinic found for this user");
+        const { success, data, error: clinicError } = await getMyClinic();
+
+        if (!success || !data?.clinic) {
+          setError(clinicError || "No clinic found for this user");
           setLoading(false);
           return;
         }
 
-        // Get the first clinic (users typically belong to one clinic)
-        const clinic = data.clinics[0];
-        setClinicId(clinic.id);
-
-        // Use the user's actual role from auth context
-        setUserRole(user.role);
-
+        setClinicId(data.clinic.id);
         setLoading(false);
       } catch (err) {
         console.error("Error initializing dashboard:", err);
@@ -54,9 +49,9 @@ const ProviderDashboard = () => {
     };
 
     initializeDashboard();
-  }, [user, getClinics]);
+  }, [user, getMyClinic]);
 
-  if (loading || clinicsLoading) {
+  if (loading || providerLoading) {
     return (
       <div className="flex h-screen items-center justify-center">
         <div className="text-center">

--- a/src/views/provider/telemedicine/components/ProviderSidebarComponents.jsx
+++ b/src/views/provider/telemedicine/components/ProviderSidebarComponents.jsx
@@ -1,9 +1,11 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import Card from "components/card";
 import { FaStethoscope, FaFileMedical } from "react-icons/fa";
 import { MdSchedule, MdAssignment } from "react-icons/md";
 
 export const ProviderQuickActionsCard = () => {
+  const navigate = useNavigate();
   return (
     <Card extra="p-6">
       <h4 className="mb-4 text-lg font-bold text-navy-700 dark:text-white">
@@ -11,7 +13,7 @@ export const ProviderQuickActionsCard = () => {
       </h4>
       <div className="space-y-3">
         <button
-          onClick={() => (window.location.href = "/provider/patient-records")}
+          onClick={() => navigate("/provider/patient-records")}
           className="flex w-full items-center justify-between rounded-lg border border-gray-200 p-3 hover:bg-gray-50 dark:border-gray-700"
         >
           <div className="flex items-center">
@@ -21,7 +23,7 @@ export const ProviderQuickActionsCard = () => {
           <span>→</span>
         </button>
         <button
-          onClick={() => (window.location.href = "/provider/schedule")}
+          onClick={() => navigate("/provider/schedule")}
           className="flex w-full items-center justify-between rounded-lg border border-gray-200 p-3 hover:bg-gray-50 dark:border-gray-700"
         >
           <div className="flex items-center">
@@ -31,7 +33,7 @@ export const ProviderQuickActionsCard = () => {
           <span>→</span>
         </button>
         <button
-          onClick={() => (window.location.href = "/provider/prescriptions")}
+          onClick={() => navigate("/provider/prescriptions")}
           className="flex w-full items-center justify-between rounded-lg border border-gray-200 p-3 hover:bg-gray-50 dark:border-gray-700"
         >
           <div className="flex items-center">


### PR DESCRIPTION
## Summary
Fixes 6 bugs that made the frontend dashboards completely unusable for all user roles.

## Changes

### 1. Fix ProviderDashboard using getClinics() instead of getMyClinic() (closes #42)
`src/views/provider/dashboard/index.jsx` - ProviderDashboard now calls `getMyClinic()` which properly looks up the user's clinic via `primary_clinic_id`, instead of fetching all clinics and picking the first one.

### 2. Fix admin SystemDashboard showing hardcoded fake data (closes #43)
`src/views/admin/dashboard/index.jsx` - Dashboard now fetches real data from `/api/v1/providers/clinics`, `/api/v1/users/count`, and `/health` endpoints. Removes all hardcoded stats like "1,247 clinics" and "45,823 users".

### 3. Fix duplicate React keys from Date.now() (closes #44)
`src/hooks/useToast.js` - Uses a counter suffix to guarantee unique toast IDs even when multiple toasts fire in the same millisecond.

### 4. Fix missing queryFn in React Query v5 hooks (closes #45)
`src/hooks/useStaff.js`, `src/hooks/useSymptomChecker.js` - Added `queryFn: () => Promise.resolve(null)` to all `useQuery` calls with `enabled: false` since React Query v5 requires `queryFn` even when disabled.

### 5. Fix infinite re-render loops in dashboards (closes #46)
`src/hooks/useAppointment.js` - Wrapped `getTodayAppointments`, `getPendingAppointments`, and `getAppointmentsByPatient` in `useCallback` to prevent new function references on every render, which was causing infinite useEffect re-triggers and crashing the Provider and Patient dashboards.

### 6. Fix window.location.href causing full page reloads (closes #47)
8 files updated - Replaced all `window.location.href` assignments with React Router's `navigate()` for proper SPA navigation without losing state.

## Testing
- All dashboards (admin, provider, patient) load without runtime errors
- No "Maximum update depth exceeded" errors
- No duplicate key warnings
- No missing queryFn warnings
- API calls fire exactly once per dashboard load