### PR TITLE
fix: move showToast out of render body — React 19 concurrent rendering crash

### DIFF
--- a/src/views/patient/dashboard/index.jsx
+++ b/src/views/patient/dashboard/index.jsx
@@ -132,9 +132,11 @@ const PatientDashboard = () => {
   const patientName = getPatientName(patient, user);
   const modalAppointments = getUpcomingForModal(appointments);
 
-  if (patientError) {
-    showToast("Failed to load patient profile", "error");
-  }
+  useEffect(() => {
+    if (patientError) {
+      showToast("Failed to load patient profile", "error");
+    }
+  }, [patientError, showToast]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
Fixes #49 - Patient dashboard crashed with concurrent rendering errors.

## Root Cause
`src/views/patient/dashboard/index.jsx` called `showToast()` directly in the render function body (line 135-137), which is a side effect. React 19 concurrent rendering does not allow side effects during render.

## Fix
Moved the `showToast` call into a `useEffect` that watches `patientError`:
```jsx
useEffect(() => {
    if (patientError) {
        showToast("Failed to load patient profile", "error");
    }
}, [patientError, showToast]);
```

## Testing
- Patient dashboard loads without concurrent rendering errors
- Toast still appears when there is a patient profile error