### PR TITLE
fix: telemedicine chat page infinite refresh loop

### DIFF
--- a/src/hooks/useConsultation.js
+++ b/src/hooks/useConsultation.js
@@ -209,7 +209,7 @@ export const useConsultation = () => {
     }
   };
 
-  const fetchPatientActiveConsultation = async () => {
+  const fetchPatientActiveConsultation = useCallback(async () => {
     startLoading();
     setError(null);
     try {
@@ -234,7 +234,7 @@ export const useConsultation = () => {
       stopLoading();
       return { success: false, error: msg };
     }
-  };
+  }, [queryClient, startLoading, stopLoading]);
 
   const fetchPatientConsultations = async (params = {}) => {
     startLoading();


### PR DESCRIPTION
## Summary
Fixes #61 - Telemedicine chat page kept refreshing/looping.

## Root Cause
`fetchPatientActiveConsultation` in `src/hooks/useConsultation.js` was a plain async function, not wrapped in `useCallback`. The telemedicine chat page's `useEffect` depends on it, so a new function reference on every render triggered infinite re-fetches and state updates.

## Fix
Wrapped `fetchPatientActiveConsultation` in `useCallback` with `[queryClient, startLoading, stopLoading]` dependencies — same pattern used in other hooks.

## Testing
- Telemedicine chat page loads once without refreshing
- Active consultation fetch happens exactly once on mount