### PR TITLE
fix: add robust fetch guard to telemedicine chat useEffect

### DIFF
--- a/src/views/patient/telemedicine-chat/index.jsx
+++ b/src/views/patient/telemedicine-chat/index.jsx
@@ -94,15 +94,15 @@ const TelemedicineChat = () => {
   }, [consultationId]);
 
   // ── On mount: check for active consultation + load providers ─────────────
+  const hasInitialFetched = useRef(false);
   useEffect(() => {
+    if (hasInitialFetched.current) return;
+    hasInitialFetched.current = true;
     fetchPatientActiveConsultation();
     fetchAvailableProviders();
     fetchEligibleSession();
-  }, [
-    fetchPatientActiveConsultation,
-    fetchAvailableProviders,
-    fetchEligibleSession,
-  ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ── When active consultation is found, load messages + note ─────────────
   useEffect(() => {


### PR DESCRIPTION
## Summary
Follow-up fix for #61 — adds a useRef guard to prevent the telemedicine chat useEffect from ever re-triggering after initial mount.

## Changes
Added `hasInitialFetched` ref guard that ensures the on-mount data fetching (active consultation, available providers, eligible session) happens exactly once, regardless of any function reference changes.

## Root Cause
While `fetchPatientActiveConsultation` is now wrapped in `useCallback`, the component had no guard against edge cases where React Query or other state changes could cause re-triggering. This ref guard is the safest pattern.

## Testing
- Telemedicine chat page loads data exactly once on mount
- No API call duplicates
- No page refresh/loop