### PR TITLE
fix: prevent textarea typing from auto-advancing symptom checker

### DIFF
--- a/src/views/patient/symptom-checker/components/QuestionCard.jsx
+++ b/src/views/patient/symptom-checker/components/QuestionCard.jsx
@@ -43,7 +43,7 @@ const QuestionCard = ({
             rows={4}
             placeholder={question.placeholder || "Type your answer here..."}
             value={currentValue || ""}
-            onChange={(e) => onResponse(question.id, e.target.value)}
+            onChange={(e) => onResponse(question.id, e.target.value, false, "textarea")}
           />
           {question.minLength && (
             <p className="mt-1 text-xs text-gray-400">

--- a/src/views/patient/symptom-checker/index.jsx
+++ b/src/views/patient/symptom-checker/index.jsx
@@ -60,7 +60,7 @@ const SymptomChecker = () => {
 
   // ─── Response handler ────────────────────────────────────────────────────────
 
-  const handleResponse = (questionId, value, isMultiple = false) => {
+  const handleResponse = (questionId, value, isMultiple = false, questionType = "single") => {
     if (isMultiple) {
       setResponses((prev) => ({
         ...prev,
@@ -69,6 +69,10 @@ const SymptomChecker = () => {
           : [...(prev[questionId] || []), value],
       }));
       // Multi-select does NOT auto-advance — user clicks Next/Skip
+    } else if (questionType === "textarea") {
+      // Textarea — update responses but do NOT auto-advance.
+      // User clicks "Next" or "Submit" when ready.
+      setResponses((prev) => ({ ...prev, [questionId]: value }));
     } else {
       const updated = { ...responses, [questionId]: value };
       setResponses(updated);


### PR DESCRIPTION
## Summary
Fixes #68 - Typing in textarea questions auto-advanced to the next question after the first keystroke.

## Root Cause
`handleResponse` treated all non-multi-select questions identically — both click-based single-select and textarea. Every `onChange` event on textareas triggered the auto-advance timeout.

## Fix
Added a `questionType` parameter to `handleResponse`. Textarea questions (`questionType === "textarea"`) update responses but skip auto-advance. Users click 'Next' button when ready.

## Testing
- Typing in 'Describe your main concern' no longer auto-advances
- Typing in medication name no longer auto-advances
- Click-based single-select questions still auto-advance correctly
- Multi-select questions unchanged