### PR TITLE
fix: prevent 401 responses from logging out user on telemedicine page

### DIFF
--- a/src/platform/http/httpClient.js
+++ b/src/platform/http/httpClient.js
@@ -21,7 +21,20 @@ export const createHttpClient = ({ baseURL, getToken, onUnauthorized }) => {
     (error) => {
       const normalized = normalizeHttpError(error);
       if (normalized.kind === "auth") {
-        onUnauthorized?.(normalized);
+        // Only trigger logout for genuine authentication failures,
+        // not for 401s caused by missing resources or permissions.
+        const msg = (normalized.message || "").toLowerCase();
+        const isRealAuthFailure =
+          msg.includes("invalid") ||
+          msg.includes("expired") ||
+          msg.includes("unauthorized") ||
+          msg.includes("unauthenticated") ||
+          msg.includes("token") ||
+          msg.includes("sign in") ||
+          msg.includes("login");
+        if (isRealAuthFailure) {
+          onUnauthorized?.(normalized);
+        }
       }
       return Promise.reject(normalized);
     }


### PR DESCRIPTION
## Summary
Fixes #91 — Provider gets logged out when accessing telemedicine page.

## Root Cause
Two telemedicine APIs returned 401 because the provider_staff user had no clinic_staff record. The httpClient treated ALL 401 responses as auth failures and called handleUnauthorized() which cleared the session and logged the user out.

## Fix
Two-part fix:
1. **Backend data**: Created clinic_staff record for provider_staff user so telemedicine APIs work correctly
2. **Frontend safeguard**: httpClient now only triggers logout for genuine authentication errors (invalid/expired token, unauthorized) — not for 401s caused by missing resources like 'No staff profile found'

## Testing
- Provider can navigate to telemedicine page without being logged out
- Navigating back to dashboard works normally
- Genuine auth failures still trigger logout